### PR TITLE
Refactor front-end scripts into ES modules

### DIFF
--- a/mprobajomesadaOHM2.html
+++ b/mprobajomesadaOHM2.html
@@ -279,8 +279,8 @@
                             <!-- El formulario de edición se cargará aquí -->
                         </div>
                         <div class="flex justify-end space-x-3 mt-6">
-                            <button onclick="cerrarModal()" class="bg-gray-500 text-white px-4 py-2 rounded-md">Cancelar</button>
-                            <button onclick="guardarEdicion()" class="bg-blue-600 text-white px-4 py-2 rounded-md">Guardar Cambios</button>
+                            <button id="cancelar-edicion-btn" class="bg-gray-500 text-white px-4 py-2 rounded-md">Cancelar</button>
+                            <button id="guardar-edicion-btn" class="bg-blue-600 text-white px-4 py-2 rounded-md">Guardar Cambios</button>
                         </div>
                     </div>
                 </div>
@@ -340,6 +340,6 @@
         </div>
     </div>
 
-    <script src="public/js/main.js"></script>
+    <script type="module" src="public/js/main.js"></script>
 </body>
 </html>

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -1,0 +1,58 @@
+import { API_URL } from './config.js';
+
+async function postJSON(payload) {
+    const response = await fetch(API_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+        },
+        body: JSON.stringify(payload),
+    });
+
+    const result = await response.json();
+
+    if (result.result !== 'success') {
+        throw new Error(result.error || 'Error desconocido');
+    }
+
+    return result.data;
+}
+
+export async function guardarMantenimiento(datos) {
+    return postJSON({
+        action: 'guardar',
+        ...datos,
+    });
+}
+
+export async function buscarMantenimientos(filtros) {
+    return postJSON({
+        action: 'buscar',
+        ...filtros,
+    });
+}
+
+export async function actualizarMantenimiento(datos) {
+    return postJSON({
+        action: 'actualizar',
+        ...datos,
+    });
+}
+
+export async function eliminarMantenimiento(id) {
+    return postJSON({
+        action: 'eliminar',
+        id,
+    });
+}
+
+export async function obtenerDashboard() {
+    const response = await fetch(`${API_URL}?action=dashboard`);
+    const result = await response.json();
+
+    if (result.result !== 'success') {
+        throw new Error(result.error || 'Error desconocido');
+    }
+
+    return result.data;
+}

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -1,0 +1,4 @@
+export const API_URL = 'https://script.google.com/macros/s/AKfycbwcgwPPAxcSzK9RywqySXV0z4MVihaEbcIwdz4_UJDxNjre9s3ZNX2dCQA3l6lBEzO1Xw/exec';
+
+export const LMIN_TO_LPH = 60;
+export const LMIN_TO_GPD = (60 * 24) / 3.78541;

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,0 +1,137 @@
+let chartMensual = null;
+let chartTecnicos = null;
+
+function getElement(id) {
+    return document.getElementById(id);
+}
+
+function createMonthlyChart(datos = []) {
+    const canvas = getElement('chart-mensual');
+    if (!canvas) {
+        return;
+    }
+
+    if (chartMensual) {
+        chartMensual.destroy();
+    }
+
+    chartMensual = new Chart(canvas, {
+        type: 'bar',
+        data: {
+            labels: ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'],
+            datasets: [
+                {
+                    label: 'Mantenimientos por Mes',
+                    data: datos,
+                    backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                    borderColor: 'rgba(54, 162, 235, 1)',
+                    borderWidth: 1,
+                },
+            ],
+        },
+        options: {
+            responsive: true,
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        stepSize: 1,
+                    },
+                },
+            },
+        },
+    });
+}
+
+function createTechnicianChart(datos = []) {
+    const canvas = getElement('chart-tecnicos');
+    if (!canvas) {
+        return;
+    }
+
+    if (chartTecnicos) {
+        chartTecnicos.destroy();
+    }
+
+    chartTecnicos = new Chart(canvas, {
+        type: 'pie',
+        data: {
+            labels: datos.map(d => d.tecnico),
+            datasets: [
+                {
+                    data: datos.map(d => d.count),
+                    backgroundColor: [
+                        'rgba(255, 99, 132, 0.5)',
+                        'rgba(54, 162, 235, 0.5)',
+                        'rgba(255, 206, 86, 0.5)',
+                        'rgba(75, 192, 192, 0.5)',
+                        'rgba(153, 102, 255, 0.5)',
+                        'rgba(255, 159, 64, 0.5)',
+                    ],
+                    borderWidth: 1,
+                },
+            ],
+        },
+        options: {
+            responsive: true,
+        },
+    });
+}
+
+function renderUpcomingMaintenances(mantenimientos = []) {
+    const tabla = getElement('tabla-proximos');
+    if (!tabla) {
+        return;
+    }
+
+    tabla.innerHTML = '';
+
+    if (!mantenimientos.length) {
+        const emptyRow = document.createElement('tr');
+        const emptyCell = document.createElement('td');
+        emptyCell.colSpan = 4;
+        emptyCell.className = 'px-6 py-4 text-center';
+        emptyCell.textContent = 'No hay próximos mantenimientos';
+        emptyRow.appendChild(emptyCell);
+        tabla.appendChild(emptyRow);
+        return;
+    }
+
+    mantenimientos.forEach(m => {
+        const fila = document.createElement('tr');
+
+        const createCell = (text) => {
+            const cell = document.createElement('td');
+            cell.className = 'px-6 py-4 whitespace-nowrap';
+            cell.textContent = text;
+            return cell;
+        };
+
+        fila.appendChild(createCell(m.cliente || 'N/A'));
+        fila.appendChild(createCell(m.fecha || 'N/A'));
+        fila.appendChild(createCell(m.tecnico || 'N/A'));
+        fila.appendChild(createCell(`${m.dias_restantes} días`));
+
+        tabla.appendChild(fila);
+    });
+}
+
+export function renderDashboard(data) {
+    if (!data) {
+        return;
+    }
+
+    const total = getElement('total-mantenimientos');
+    const mes = getElement('mantenimientos-mes');
+    const proximos = getElement('proximos-mantenimientos');
+    const tecnicos = getElement('tecnicos-activos');
+
+    if (total) total.textContent = data.total ?? 0;
+    if (mes) mes.textContent = data.esteMes ?? 0;
+    if (proximos) proximos.textContent = data.proximos ?? 0;
+    if (tecnicos) tecnicos.textContent = data.tecnicos ?? 0;
+
+    createMonthlyChart(Array.isArray(data.mensual) ? data.mensual : []);
+    createTechnicianChart(Array.isArray(data.tecnicosData) ? data.tecnicosData : []);
+    renderUpcomingMaintenances(Array.isArray(data.proximosMantenimientos) ? data.proximosMantenimientos : []);
+}

--- a/public/js/forms.js
+++ b/public/js/forms.js
@@ -1,0 +1,218 @@
+import { LMIN_TO_GPD, LMIN_TO_LPH } from './config.js';
+
+function getElement(id) {
+    return document.getElementById(id);
+}
+
+function setDefaultDate() {
+    const fechaInput = getElement('fecha');
+    if (fechaInput) {
+        const today = new Date();
+        fechaInput.value = today.toLocaleDateString('es-AR', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+        });
+    }
+}
+
+function calculateAll() {
+    const condRedFound = parseFloat(getElement('cond_red_found')?.value) || 0;
+    const condPermFound = parseFloat(getElement('cond_perm_found')?.value) || 0;
+    const condRedLeft = parseFloat(getElement('cond_red_left')?.value) || 0;
+    const condPermLeft = parseFloat(getElement('cond_perm_left')?.value) || 0;
+
+    const caudalPermFound = parseFloat(getElement('caudal_perm_found')?.value) || 0;
+    const caudalRechFound = parseFloat(getElement('caudal_rech_found')?.value) || 0;
+    const caudalPermLeft = parseFloat(getElement('caudal_perm_left')?.value) || 0;
+    const caudalRechLeft = parseFloat(getElement('caudal_rech_left')?.value) || 0;
+
+    const rechazoFound = condRedFound > 0 ? ((1 - (condPermFound / condRedFound)) * 100).toFixed(2) : '';
+    const rechazoLeft = condRedLeft > 0 ? ((1 - (condPermLeft / condRedLeft)) * 100).toFixed(2) : '';
+
+    const rechazoFoundInput = getElement('rechazo_found');
+    const rechazoLeftInput = getElement('rechazo_left');
+    if (rechazoFoundInput) {
+        rechazoFoundInput.value = rechazoFound ? `${rechazoFound} %` : '';
+    }
+    if (rechazoLeftInput) {
+        rechazoLeftInput.value = rechazoLeft ? `${rechazoLeft} %` : '';
+    }
+
+    const relacionFound = caudalPermFound > 0 ? (caudalRechFound / caudalPermFound).toFixed(1) : '';
+    const relacionLeft = caudalPermLeft > 0 ? (caudalRechLeft / caudalPermLeft).toFixed(1) : '';
+
+    const relacionFoundInput = getElement('relacion_found');
+    const relacionLeftInput = getElement('relacion_left');
+    if (relacionFoundInput) {
+        relacionFoundInput.value = relacionFound ? `${relacionFound}:1` : '';
+    }
+    if (relacionLeftInput) {
+        relacionLeftInput.value = relacionLeft ? `${relacionLeft}:1` : '';
+    }
+}
+
+function updateConversions(inputEl, outputEl) {
+    const lmin = parseFloat(inputEl.value);
+    if (!Number.isNaN(lmin) && lmin >= 0) {
+        const lph = lmin * LMIN_TO_LPH;
+        const gpd = lmin * LMIN_TO_GPD;
+        outputEl.textContent = `(${lph.toFixed(1)} l/h | ${gpd.toFixed(0)} GPD)`;
+    } else {
+        outputEl.textContent = '';
+    }
+}
+
+function configureConversionInputs() {
+    const conversionPairs = [
+        ['caudal_perm_found', 'caudal_perm_found_conv'],
+        ['caudal_perm_left', 'caudal_perm_left_conv'],
+        ['caudal_rech_found', 'caudal_rech_found_conv'],
+        ['caudal_rech_left', 'caudal_rech_left_conv'],
+    ];
+
+    conversionPairs.forEach(([inputId, outputId]) => {
+        const input = getElement(inputId);
+        const output = getElement(outputId);
+        if (input && output) {
+            input.addEventListener('input', () => updateConversions(input, output));
+        }
+    });
+}
+
+function setStatusColor(selectElement) {
+    selectElement.classList.remove('status-pass', 'status-fail', 'status-na');
+    const value = selectElement.value;
+    if (value === 'Pasa' || value === 'Realizada' || value === 'No') {
+        selectElement.classList.add('status-pass');
+    } else if (value === 'Falla' || value === 'No Realizada' || value === 'Sí') {
+        selectElement.classList.add('status-fail');
+    } else {
+        selectElement.classList.add('status-na');
+    }
+}
+
+function applyStatusColors() {
+    const statusSelects = document.querySelectorAll('select[id$="_found"], select[id$="_left"], select#sanitizacion_status');
+    statusSelects.forEach(setStatusColor);
+}
+
+function configureStatusSelects() {
+    const statusSelects = document.querySelectorAll('select[id$="_found"], select[id$="_left"], select#sanitizacion_status');
+    statusSelects.forEach(select => {
+        setStatusColor(select);
+        select.addEventListener('change', () => setStatusColor(select));
+    });
+}
+
+function configureNumberInputs() {
+    const inputs = document.querySelectorAll('input[type="number"]');
+    inputs.forEach(input => {
+        input.addEventListener('input', calculateAll);
+    });
+}
+
+function clearDerivedFields() {
+    ['rechazo_found', 'rechazo_left', 'relacion_found', 'relacion_left'].forEach(id => {
+        const element = getElement(id);
+        if (element) {
+            element.value = '';
+        }
+    });
+}
+
+function clearConversionOutputs() {
+    ['caudal_perm_found_conv', 'caudal_perm_left_conv', 'caudal_rech_found_conv', 'caudal_rech_left_conv'].forEach(id => {
+        const element = getElement(id);
+        if (element) {
+            element.textContent = '';
+        }
+    });
+}
+
+function getValue(id) {
+    return getElement(id)?.value || '';
+}
+
+export function initializeForm() {
+    setDefaultDate();
+    configureNumberInputs();
+    configureConversionInputs();
+    configureStatusSelects();
+    calculateAll();
+}
+
+export function resetForm() {
+    const form = getElement('maintenance-form');
+    if (form) {
+        form.reset();
+    }
+    setDefaultDate();
+    clearDerivedFields();
+    clearConversionOutputs();
+    applyStatusColors();
+}
+
+export function getFormData() {
+    return {
+        cliente: getValue('cliente'),
+        fecha: getValue('fecha'),
+        direccion: getValue('direccion'),
+        tecnico: getValue('tecnico'),
+        modelo: getValue('modelo'),
+        id_interna: getValue('id_interna'),
+        n_serie: getValue('n_serie'),
+        proximo_mant: getValue('proximo_mant'),
+        fugas_found: getValue('fugas_found'),
+        fugas_left: getValue('fugas_left'),
+        cond_red_found: getValue('cond_red_found') || 0,
+        cond_red_left: getValue('cond_red_left') || 0,
+        cond_perm_found: getValue('cond_perm_found') || 0,
+        cond_perm_left: getValue('cond_perm_left') || 0,
+        rechazo_found: getValue('rechazo_found'),
+        rechazo_left: getValue('rechazo_left'),
+        presion_found: getValue('presion_found') || 0,
+        presion_left: getValue('presion_left') || 0,
+        caudal_perm_found: getValue('caudal_perm_found') || 0,
+        caudal_perm_left: getValue('caudal_perm_left') || 0,
+        caudal_rech_found: getValue('caudal_rech_found') || 0,
+        caudal_rech_left: getValue('caudal_rech_left') || 0,
+        relacion_found: getValue('relacion_found'),
+        relacion_left: getValue('relacion_left'),
+        precarga_found: getValue('precarga_found') || 0,
+        precarga_left: getValue('precarga_left') || 0,
+        presostato_alta_found: getValue('presostato_alta_found'),
+        presostato_alta_left: getValue('presostato_alta_left'),
+        presostato_baja_found: getValue('presostato_baja_found'),
+        presostato_baja_left: getValue('presostato_baja_left'),
+        etapa1_detalles: getValue('etapa1_detalles'),
+        etapa1_accion: document.querySelector('input[name="etapa1_action"]:checked')?.value || '',
+        etapa2_detalles: getValue('etapa2_detalles'),
+        etapa2_accion: document.querySelector('input[name="etapa2_action"]:checked')?.value || '',
+        etapa3_detalles: getValue('etapa3_detalles'),
+        etapa3_accion: document.querySelector('input[name="etapa3_action"]:checked')?.value || '',
+        etapa4_detalles: getValue('etapa4_detalles'),
+        etapa4_accion: document.querySelector('input[name="etapa4_action"]:checked')?.value || '',
+        etapa5_detalles: getValue('etapa5_detalles'),
+        etapa5_accion: document.querySelector('input[name="etapa5_action"]:checked')?.value || '',
+        etapa6_detalles: getValue('etapa6_detalles'),
+        etapa6_accion: document.querySelector('input[name="etapa6_action"]:checked')?.value || '',
+        sanitizacion: getValue('sanitizacion_status'),
+        resumen: getValue('resumen'),
+        numero_reporte: `REP-${Date.now()}`,
+    };
+}
+
+export function setReportNumber(reportNumber) {
+    const display = getElement('report-number-display');
+    if (display) {
+        display.textContent = reportNumber;
+    }
+}
+
+export function generateReportNumber() {
+    const now = new Date();
+    const padZero = (num) => String(num).padStart(2, '0');
+    const timestamp = `${now.getFullYear()}${padZero(now.getMonth() + 1)}${padZero(now.getDate())}-${padZero(now.getHours())}${padZero(now.getMinutes())}${padZero(now.getSeconds())}`;
+    return `REP-${timestamp}`;
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,103 +1,9 @@
-// Configuración
-const API_URL = 'https://script.google.com/macros/s/AKfycbwcgwPPAxcSzK9RywqySXV0z4MVihaEbcIwdz4_UJDxNjre9s3ZNX2dCQA3l6lBEzO1Xw/exec';
+import { guardarMantenimiento, buscarMantenimientos, actualizarMantenimiento, eliminarMantenimiento, obtenerDashboard } from './api.js';
+import { renderDashboard } from './dashboard.js';
+import { generateReportNumber, getFormData, initializeForm, resetForm, setReportNumber } from './forms.js';
+import { clearSearchResults, getEditFormValues, openEditModal, closeEditModal, renderSearchResults } from './search.js';
 
-// Variables globales
-let mantenimientos = [];
-let mantenimientoEditando = null;
-let chartMensual = null;
-let chartTecnicos = null;
-const LMIN_TO_LPH = 60;
-const LMIN_TO_GPD = (60 * 24) / 3.78541;
-
-// Función para inicializar todo
-function inicializarSistema() {
-    console.log('🔧 Inicializando sistema...');
-
-    // Configurar fecha automática
-    const today = new Date();
-    const fechaInput = document.getElementById('fecha');
-    if (fechaInput) {
-        fechaInput.value = today.toLocaleDateString('es-AR', { year: 'numeric', month: '2-digit', day: '2-digit' });
-    }
-
-    // Conectar botones principales
-    const guardarBtn = document.getElementById('guardarButton');
-    const resetBtn = document.getElementById('resetButton');
-    const buscarBtn = document.getElementById('buscar-btn');
-    const limpiarBtn = document.getElementById('limpiar-btn');
-
-    if (guardarBtn) {
-        guardarBtn.onclick = guardarNuevoMantenimiento;
-        console.log('✅ Botón guardar conectado');
-    } else {
-        console.log('❌ No se encontró botón guardar');
-    }
-
-    if (resetBtn) {
-        resetBtn.onclick = function() {
-            document.getElementById('maintenance-form').reset();
-            const today = new Date();
-            const fechaInput = document.getElementById('fecha');
-            if (fechaInput) {
-                fechaInput.value = today.toLocaleDateString('es-AR', { year: 'numeric', month: '2-digit', day: '2-digit' });
-            }
-        };
-        console.log('✅ Botón reset conectado');
-    }
-
-    if (buscarBtn) {
-        buscarBtn.onclick = buscarMantenimientos;
-        console.log('✅ Botón buscar conectado');
-    }
-
-    if (limpiarBtn) {
-        limpiarBtn.onclick = limpiarBusqueda;
-        console.log('✅ Botón limpiar conectado');
-    }
-
-    // Conectar pestañas
-    const tabNuevoBtn = document.getElementById('tab-nuevo-btn');
-    const tabBuscarBtn = document.getElementById('tab-buscar-btn');
-    const tabDashboardBtn = document.getElementById('tab-dashboard-btn');
-
-    if (tabNuevoBtn) tabNuevoBtn.onclick = () => showTab('nuevo');
-    if (tabBuscarBtn) tabBuscarBtn.onclick = () => showTab('buscar');
-    if (tabDashboardBtn) tabDashboardBtn.onclick = () => showTab('dashboard');
-
-    console.log('✅ Pestañas conectadas');
-
-    // Configurar eventos para cálculos automáticos
-    const inputs = document.querySelectorAll('input[type="number"]');
-    inputs.forEach(input => {
-        input.addEventListener('input', calculateAll);
-    });
-
-    // Configurar conversiones de caudal
-    const configurarConversiones = () => {
-        const caudalInputs = ['caudal_perm_found', 'caudal_perm_left', 'caudal_rech_found', 'caudal_rech_left'];
-        caudalInputs.forEach(id => {
-            const input = document.getElementById(id);
-            const conv = document.getElementById(`${id}_conv`);
-            if (input && conv) {
-                input.addEventListener('input', () => updateConversions(input, conv));
-            }
-        });
-    };
-    configurarConversiones();
-
-    // Configurar colores de estado
-    const statusSelects = document.querySelectorAll('select[id$="_found"], select[id$="_left"], select#sanitizacion_status');
-    statusSelects.forEach(select => {
-        setStatusColor(select);
-        select.addEventListener('change', () => setStatusColor(select));
-    });
-
-    console.log('🎉 Sistema inicializado correctamente');
-}
-
-// Mostrar/ocultar pestañas
 function showTab(tabName) {
-    console.log('Cambiando a pestaña:', tabName);
     document.querySelectorAll('.tab-content').forEach(tab => tab.classList.add('hidden'));
     document.querySelectorAll('.tab-button').forEach(btn => btn.classList.remove('active'));
 
@@ -106,469 +12,188 @@ function showTab(tabName) {
         tabElement.classList.remove('hidden');
     }
 
-    // Activar el botón de la pestaña correspondiente
-    const tabButtons = document.querySelectorAll('.tab-button');
-    tabButtons.forEach(button => {
-        if (button.id === `tab-${tabName}-btn`) {
-            button.classList.add('active');
-        }
-    });
+    const tabButton = document.getElementById(`tab-${tabName}-btn`);
+    if (tabButton) {
+        tabButton.classList.add('active');
+    }
 
     if (tabName === 'dashboard') {
-        cargarDashboard();
+        loadDashboard();
     }
 }
 
-// Funciones del formulario original
-function calculateAll() {
-    const condRedFound = parseFloat(document.getElementById('cond_red_found').value) || 0;
-    const condPermFound = parseFloat(document.getElementById('cond_perm_found').value) || 0;
-    const condRedLeft = parseFloat(document.getElementById('cond_red_left').value) || 0;
-    const condPermLeft = parseFloat(document.getElementById('cond_perm_left').value) || 0;
-
-    const caudalPermFound = parseFloat(document.getElementById('caudal_perm_found').value) || 0;
-    const caudalRechFound = parseFloat(document.getElementById('caudal_rech_found').value) || 0;
-    const caudalPermLeft = parseFloat(document.getElementById('caudal_perm_left').value) || 0;
-    const caudalRechLeft = parseFloat(document.getElementById('caudal_rech_left').value) || 0;
-
-    // Calcular rechazo iónico
-    const rechazoFound = condRedFound > 0 ? ((1 - (condPermFound / condRedFound)) * 100).toFixed(2) : '';
-    const rechazoLeft = condRedLeft > 0 ? ((1 - (condPermLeft / condRedLeft)) * 100).toFixed(2) : '';
-
-    document.getElementById('rechazo_found').value = rechazoFound ? `${rechazoFound} %` : '';
-    document.getElementById('rechazo_left').value = rechazoLeft ? `${rechazoLeft} %` : '';
-
-    // Calcular relación rechazo:permeado
-    const relacionFound = caudalPermFound > 0 ? (caudalRechFound / caudalPermFound).toFixed(1) : '';
-    const relacionLeft = caudalPermLeft > 0 ? (caudalRechLeft / caudalPermLeft).toFixed(1) : '';
-
-    document.getElementById('relacion_found').value = relacionFound ? `${relacionFound}:1` : '';
-    document.getElementById('relacion_left').value = relacionLeft ? `${relacionLeft}:1` : '';
-}
-
-function updateConversions(inputEl, outputEl) {
-    const lmin = parseFloat(inputEl.value);
-    if (!isNaN(lmin) && lmin >= 0) {
-        const lph = lmin * LMIN_TO_LPH;
-        const gpd = lmin * LMIN_TO_GPD;
-        outputEl.textContent = `(${lph.toFixed(1)} l/h | ${gpd.toFixed(0)} GPD)`;
-    } else {
-        outputEl.textContent = '';
-    }
-}
-
-function setStatusColor(selectElement) {
-    selectElement.classList.remove('status-pass', 'status-fail', 'status-na');
-    const value = selectElement.value;
-    if (value === 'Pasa' || value === 'Realizada' || value === 'No') {
-        selectElement.classList.add('status-pass');
-    } else if (value === 'Falla' || value === 'No Realizada' || value === 'Sí') {
-        selectElement.classList.add('status-fail');
-    } else {
-        selectElement.classList.add('status-na');
-    }
-}
-
-// Función para guardar el nuevo mantenimiento
-async function guardarNuevoMantenimiento() {
-    console.log('💾 Intentando guardar mantenimiento...');
-
+async function handleGuardarClick() {
     const guardarBtn = document.getElementById('guardarButton');
+    if (!guardarBtn) {
+        return;
+    }
+
     const originalText = guardarBtn.textContent;
-    guardarBtn.textContent = "Guardando...";
+    guardarBtn.textContent = 'Guardando...';
     guardarBtn.disabled = true;
 
     try {
-        const datos = {
-            action: 'guardar',
-            cliente: document.getElementById('cliente').value,
-            fecha: document.getElementById('fecha').value,
-            direccion: document.getElementById('direccion').value,
-            tecnico: document.getElementById('tecnico').value,
-            modelo: document.getElementById('modelo').value,
-            id_interna: document.getElementById('id_interna').value,
-            n_serie: document.getElementById('n_serie').value,
-            proximo_mant: document.getElementById('proximo_mant').value,
-            fugas_found: document.getElementById('fugas_found').value,
-            fugas_left: document.getElementById('fugas_left').value,
-            cond_red_found: document.getElementById('cond_red_found').value || 0,
-            cond_red_left: document.getElementById('cond_red_left').value || 0,
-            cond_perm_found: document.getElementById('cond_perm_found').value || 0,
-            cond_perm_left: document.getElementById('cond_perm_left').value || 0,
-            rechazo_found: document.getElementById('rechazo_found').value,
-            rechazo_left: document.getElementById('rechazo_left').value,
-            presion_found: document.getElementById('presion_found').value || 0,
-            presion_left: document.getElementById('presion_left').value || 0,
-            caudal_perm_found: document.getElementById('caudal_perm_found').value || 0,
-            caudal_perm_left: document.getElementById('caudal_perm_left').value || 0,
-            caudal_rech_found: document.getElementById('caudal_rech_found').value || 0,
-            caudal_rech_left: document.getElementById('caudal_rech_left').value || 0,
-            relacion_found: document.getElementById('relacion_found').value,
-            relacion_left: document.getElementById('relacion_left').value,
-            precarga_found: document.getElementById('precarga_found').value || 0,
-            precarga_left: document.getElementById('precarga_left').value || 0,
-            presostato_alta_found: document.getElementById('presostato_alta_found').value,
-            presostato_alta_left: document.getElementById('presostato_alta_left').value,
-            presostato_baja_found: document.getElementById('presostato_baja_found').value,
-            presostato_baja_left: document.getElementById('presostato_baja_left').value,
-            etapa1_detalles: document.getElementById('etapa1_detalles').value,
-            etapa1_accion: document.querySelector('input[name="etapa1_action"]:checked')?.value || '',
-            etapa2_detalles: document.getElementById('etapa2_detalles').value,
-            etapa2_accion: document.querySelector('input[name="etapa2_action"]:checked')?.value || '',
-            etapa3_detalles: document.getElementById('etapa3_detalles').value,
-            etapa3_accion: document.querySelector('input[name="etapa3_action"]:checked')?.value || '',
-            etapa4_detalles: document.getElementById('etapa4_detalles').value,
-            etapa4_accion: document.querySelector('input[name="etapa4_action"]:checked')?.value || '',
-            etapa5_detalles: document.getElementById('etapa5_detalles').value,
-            etapa5_accion: document.querySelector('input[name="etapa5_action"]:checked')?.value || '',
-            etapa6_detalles: document.getElementById('etapa6_detalles').value,
-            etapa6_accion: document.querySelector('input[name="etapa6_action"]:checked')?.value || '',
-            sanitizacion: document.getElementById('sanitizacion_status').value,
-            resumen: document.getElementById('resumen').value,
-            numero_reporte: 'REP-' + new Date().getTime()
-        };
+        const datos = getFormData();
+        await guardarMantenimiento(datos);
+        alert('✅ Mantenimiento guardado correctamente en el sistema');
 
-        console.log('📤 Enviando datos:', datos);
+        const reportNumber = generateReportNumber();
+        setReportNumber(reportNumber);
 
-        const response = await fetch(API_URL, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'text/plain; charset=utf-8'
-            },
-            body: JSON.stringify(datos)
-        });
-
-        const result = await response.json();
-        console.log('📥 Respuesta del servidor:', result);
-
-        if (result.result === 'success') {
-            alert('✅ Mantenimiento guardado correctamente en el sistema');
-
-            // Generar número de reporte para impresión
-            const now = new Date();
-            const padZero = (num) => String(num).padStart(2, '0');
-            const timestamp = `${now.getFullYear()}${padZero(now.getMonth() + 1)}${padZero(now.getDate())}-${padZero(now.getHours())}${padZero(now.getMinutes())}${padZero(now.getSeconds())}`;
-            document.getElementById('report-number-display').textContent = `REP-${timestamp}`;
-
-            // Imprimir después de guardar
-            setTimeout(() => {
-                window.print();
-            }, 500);
-
-        } else {
-            throw new Error(result.error || 'Error desconocido');
-        }
+        setTimeout(() => {
+            window.print();
+        }, 500);
     } catch (error) {
-        console.error('❌ Error:', error);
-        alert('❌ Error al guardar los datos: ' + error.message);
+        console.error('Error al guardar mantenimiento:', error);
+        alert(`❌ Error al guardar los datos: ${error.message}`);
     } finally {
         guardarBtn.textContent = originalText;
         guardarBtn.disabled = false;
     }
 }
 
-// Buscar mantenimientos
-async function buscarMantenimientos() {
-    console.log('🔍 Buscando mantenimientos...');
-    const cliente = document.getElementById('buscar-cliente').value;
-    const tecnico = document.getElementById('buscar-tecnico').value;
-    const fecha = document.getElementById('buscar-fecha').value;
+async function handleBuscarClick() {
+    const filtros = {
+        cliente: document.getElementById('buscar-cliente')?.value || '',
+        tecnico: document.getElementById('buscar-tecnico')?.value || '',
+        fecha: document.getElementById('buscar-fecha')?.value || '',
+    };
 
     try {
-        const response = await fetch(API_URL, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'text/plain; charset=utf-8'
-            },
-            body: JSON.stringify({
-                action: 'buscar',
-                cliente: cliente,
-                tecnico: tecnico,
-                fecha: fecha
-            })
+        const resultados = await buscarMantenimientos(filtros);
+        renderSearchResults(resultados, {
+            onEdit: handleEditarMantenimiento,
+            onDelete: handleEliminarMantenimiento,
         });
-
-        const result = await response.json();
-
-        if (result.result === 'success') {
-            mantenimientos = result.data;
-            mostrarResultadosBusqueda();
-        } else {
-            throw new Error(result.error);
-        }
     } catch (error) {
         console.error('Error buscando mantenimientos:', error);
         alert('Error al buscar mantenimientos');
     }
 }
 
-// Mostrar resultados de búsqueda
-function mostrarResultadosBusqueda() {
-    const tabla = document.getElementById('tabla-resultados');
-    if (!tabla) {
-        console.log('❌ No se encontró la tabla de resultados');
-        return;
-    }
-
-    tabla.innerHTML = '';
-
-    if (mantenimientos.length === 0) {
-        tabla.innerHTML = '<tr><td colspan="5" class="px-6 py-4 text-center">No se encontraron resultados</td></tr>';
-        document.getElementById('resultados-busqueda').classList.remove('hidden');
-        return;
-    }
-
-    mantenimientos.forEach(mantenimiento => {
-        const fila = document.createElement('tr');
-        fila.innerHTML = `
-            <td class="px-6 py-4 whitespace-nowrap">${mantenimiento.Cliente || 'N/A'}</td>
-            <td class="px-6 py-4 whitespace-nowrap">${mantenimiento.Fecha_Servicio || 'N/A'}</td>
-            <td class="px-6 py-4 whitespace-nowrap">${mantenimiento.Tecnico_Asignado || 'N/A'}</td>
-            <td class="px-6 py-4 whitespace-nowrap">${mantenimiento.Modelo_Equipo || 'N/A'}</td>
-            <td class="px-6 py-4 whitespace-nowrap">
-                <button onclick="editarMantenimiento('${mantenimiento.ID_Unico}')" class="text-blue-600 hover:text-blue-900 mr-2">Editar</button>
-                <button onclick="eliminarMantenimiento('${mantenimiento.ID_Unico}')" class="text-red-600 hover:text-red-900">Eliminar</button>
-            </td>
-        `;
-        tabla.appendChild(fila);
-    });
-
-    document.getElementById('resultados-busqueda').classList.remove('hidden');
-}
-
-// Editar mantenimiento
-function editarMantenimiento(id) {
-    mantenimientoEditando = mantenimientos.find(m => m.ID_Unico === id);
-
-    document.getElementById('formulario-edicion').innerHTML = `
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-            <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Cliente</label>
-                <input type="text" id="edit-cliente" value="${mantenimientoEditando.Cliente || ''}" class="w-full border-gray-300 rounded-md p-2">
-            </div>
-            <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Fecha Servicio</label>
-                <input type="date" id="edit-fecha" value="${mantenimientoEditando.Fecha_Servicio || ''}" class="w-full border-gray-300 rounded-md p-2">
-            </div>
-            <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Técnico</label>
-                <input type="text" id="edit-tecnico" value="${mantenimientoEditando.Tecnico_Asignado || ''}" class="w-full border-gray-300 rounded-md p-2">
-            </div>
-            <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Próximo Mantenimiento</label>
-                <input type="date" id="edit-proximo-mant" value="${mantenimientoEditando.Proximo_Mantenimiento || ''}" class="w-full border-gray-300 rounded-md p-2">
-            </div>
-            <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Conductividad Permeado</label>
-                <input type="number" id="edit-cond-perm" value="${mantenimientoEditando.Conductividad_Permeado_Left || 0}" class="w-full border-gray-300 rounded-md p-2">
-            </div>
-            <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Resumen</label>
-                <textarea id="edit-resumen" rows="3" class="w-full border-gray-300 rounded-md p-2">${mantenimientoEditando.Resumen_Recomendaciones || ''}</textarea>
-            </div>
-        </div>
-        <input type="hidden" id="edit-id" value="${mantenimientoEditando.ID_Unico}">
-    `;
-
-    document.getElementById('modal-edicion').classList.remove('hidden');
-}
-
-// Guardar edición
-async function guardarEdicion() {
-    try {
-        const response = await fetch(API_URL, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'text/plain; charset=utf-8'
-            },
-            body: JSON.stringify({
-                action: 'actualizar',
-                id: document.getElementById('edit-id').value,
-                cliente: document.getElementById('edit-cliente').value,
-                fecha_servicio: document.getElementById('edit-fecha').value,
-                tecnico_asignado: document.getElementById('edit-tecnico').value,
-                proximo_mantenimiento: document.getElementById('edit-proximo-mant').value,
-                conductividad_permeado_left: document.getElementById('edit-cond-perm').value,
-                resumen_recomendaciones: document.getElementById('edit-resumen').value
-            })
-        });
-
-        const result = await response.json();
-
-        if (result.result === 'success') {
-            alert('✅ Cambios guardados correctamente');
-            cerrarModal();
-            buscarMantenimientos();
-        } else {
-            throw new Error(result.error);
+function handleLimpiarBusqueda() {
+    const inputs = ['buscar-cliente', 'buscar-tecnico', 'buscar-fecha'];
+    inputs.forEach(id => {
+        const element = document.getElementById(id);
+        if (element) {
+            element.value = '';
         }
+    });
+    clearSearchResults();
+}
+
+function handleEditarMantenimiento(mantenimiento) {
+    if (!mantenimiento) {
+        return;
+    }
+    openEditModal(mantenimiento);
+}
+
+async function handleEliminarMantenimiento(mantenimiento) {
+    if (!mantenimiento?.ID_Unico) {
+        return;
+    }
+
+    const confirmacion = window.confirm('¿Estás seguro de que quieres eliminar este mantenimiento?');
+    if (!confirmacion) {
+        return;
+    }
+
+    try {
+        await eliminarMantenimiento(mantenimiento.ID_Unico);
+        alert('✅ Mantenimiento eliminado correctamente');
+        await handleBuscarClick();
+    } catch (error) {
+        console.error('Error eliminando mantenimiento:', error);
+        alert('Error al eliminar mantenimiento');
+    }
+}
+
+async function handleGuardarEdicion() {
+    try {
+        const datos = getEditFormValues();
+        await actualizarMantenimiento(datos);
+        alert('✅ Cambios guardados correctamente');
+        closeEditModal();
+        await handleBuscarClick();
     } catch (error) {
         console.error('Error guardando cambios:', error);
         alert('Error al guardar cambios');
     }
 }
 
-// Cerrar modal
-function cerrarModal() {
-    document.getElementById('modal-edicion').classList.add('hidden');
-}
-
-// Eliminar mantenimiento
-async function eliminarMantenimiento(id) {
-    if (confirm('¿Estás seguro de que quieres eliminar este mantenimiento?')) {
-        try {
-            const response = await fetch(API_URL, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'text/plain; charset=utf-8'
-                },
-                body: JSON.stringify({
-                    action: 'eliminar',
-                    id: id
-                })
-            });
-
-            const result = await response.json();
-
-            if (result.result === 'success') {
-                alert('✅ Mantenimiento eliminado correctamente');
-                buscarMantenimientos();
-            } else {
-                throw new Error(result.error);
-            }
-        } catch (error) {
-            console.error('Error eliminando mantenimiento:', error);
-            alert('Error al eliminar mantenimiento');
-        }
-    }
-}
-
-// Limpiar búsqueda
-function limpiarBusqueda() {
-    document.getElementById('buscar-cliente').value = '';
-    document.getElementById('buscar-tecnico').value = '';
-    document.getElementById('buscar-fecha').value = '';
-    document.getElementById('resultados-busqueda').classList.add('hidden');
-}
-
-// Cargar dashboard
-async function cargarDashboard() {
+async function loadDashboard() {
     try {
-        const response = await fetch(API_URL + '?action=dashboard');
-        const result = await response.json();
-
-        if (result.result === 'success') {
-            const data = result.data;
-
-            document.getElementById('total-mantenimientos').textContent = data.total;
-            document.getElementById('mantenimientos-mes').textContent = data.esteMes;
-            document.getElementById('proximos-mantenimientos').textContent = data.proximos;
-            document.getElementById('tecnicos-activos').textContent = data.tecnicos;
-
-            crearGraficoMensual(data.mensual);
-            crearGraficoTecnicos(data.tecnicosData);
-            mostrarProximosMantenimientos(data.proximosMantenimientos);
-        }
+        const data = await obtenerDashboard();
+        renderDashboard(data);
     } catch (error) {
         console.error('Error cargando dashboard:', error);
     }
 }
 
-// Crear gráfico mensual
-function crearGraficoMensual(datos) {
-    const ctx = document.getElementById('chart-mensual');
-    if (!ctx) return;
-
-    if (chartMensual) {
-        chartMensual.destroy();
-    }
-    chartMensual = new Chart(ctx, {
-        type: 'bar',
-        data: {
-            labels: ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'],
-            datasets: [{
-                label: 'Mantenimientos por Mes',
-                data: datos,
-                backgroundColor: 'rgba(54, 162, 235, 0.5)',
-                borderColor: 'rgba(54, 162, 235, 1)',
-                borderWidth: 1
-            }]
-        },
-        options: {
-            responsive: true,
-            scales: {
-                y: {
-                    beginAtZero: true,
-                    ticks: {
-                        stepSize: 1
-                    }
-                }
-            }
-        }
-    });
-}
-
-// Crear gráfico de técnicos
-function crearGraficoTecnicos(datos) {
-    const ctx = document.getElementById('chart-tecnicos');
-    if (!ctx) return;
-
-    if (chartTecnicos) {
-        chartTecnicos.destroy();
-    }
-    chartTecnicos = new Chart(ctx, {
-        type: 'pie',
-        data: {
-            labels: datos.map(d => d.tecnico),
-            datasets: [{
-                data: datos.map(d => d.count),
-                backgroundColor: [
-                    'rgba(255, 99, 132, 0.5)',
-                    'rgba(54, 162, 235, 0.5)',
-                    'rgba(255, 206, 86, 0.5)',
-                    'rgba(75, 192, 192, 0.5)',
-                    'rgba(153, 102, 255, 0.5)',
-                    'rgba(255, 159, 64, 0.5)'
-                ],
-                borderWidth: 1
-            }]
-        },
-        options: {
-            responsive: true
-        }
-    });
-}
-
-// Mostrar próximos mantenimientos
-function mostrarProximosMantenimientos(mantenimientos) {
-    const tabla = document.getElementById('tabla-proximos');
-    if (!tabla) return;
-
-    tabla.innerHTML = '';
-
-    if (mantenimientos.length === 0) {
-        tabla.innerHTML = '<tr><td colspan="4" class="px-6 py-4 text-center">No hay próximos mantenimientos</td></tr>';
-        return;
+function attachEventListeners() {
+    const guardarBtn = document.getElementById('guardarButton');
+    if (guardarBtn) {
+        guardarBtn.addEventListener('click', handleGuardarClick);
     }
 
-    mantenimientos.forEach(m => {
-        const fila = document.createElement('tr');
-        fila.innerHTML = `
-            <td class="px-6 py-4 whitespace-nowrap">${m.cliente || 'N/A'}</td>
-            <td class="px-6 py-4 whitespace-nowrap">${m.fecha || 'N/A'}</td>
-            <td class="px-6 py-4 whitespace-nowrap">${m.tecnico || 'N/A'}</td>
-            <td class="px-6 py-4 whitespace-nowrap">${m.dias_restantes} días</td>
-        `;
-        tabla.appendChild(fila);
-    });
+    const resetBtn = document.getElementById('resetButton');
+    if (resetBtn) {
+        resetBtn.addEventListener('click', resetForm);
+    }
+
+    const buscarBtn = document.getElementById('buscar-btn');
+    if (buscarBtn) {
+        buscarBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            handleBuscarClick();
+        });
+    }
+
+    const limpiarBtn = document.getElementById('limpiar-btn');
+    if (limpiarBtn) {
+        limpiarBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            handleLimpiarBusqueda();
+        });
+    }
+
+    const cancelarEdicionBtn = document.getElementById('cancelar-edicion-btn');
+    if (cancelarEdicionBtn) {
+        cancelarEdicionBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            closeEditModal();
+        });
+    }
+
+    const guardarEdicionBtn = document.getElementById('guardar-edicion-btn');
+    if (guardarEdicionBtn) {
+        guardarEdicionBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            handleGuardarEdicion();
+        });
+    }
+
+    const tabNuevoBtn = document.getElementById('tab-nuevo-btn');
+    if (tabNuevoBtn) {
+        tabNuevoBtn.addEventListener('click', () => showTab('nuevo'));
+    }
+
+    const tabBuscarBtn = document.getElementById('tab-buscar-btn');
+    if (tabBuscarBtn) {
+        tabBuscarBtn.addEventListener('click', () => showTab('buscar'));
+    }
+
+    const tabDashboardBtn = document.getElementById('tab-dashboard-btn');
+    if (tabDashboardBtn) {
+        tabDashboardBtn.addEventListener('click', () => showTab('dashboard'));
+    }
 }
 
-// Inicialización cuando el DOM esté completamente cargado
-document.addEventListener('DOMContentLoaded', function() {
-    console.log('📄 DOM cargado, inicializando sistema...');
-    inicializarSistema();
-});
+function initializeSystem() {
+    initializeForm();
+    attachEventListeners();
+    showTab('nuevo');
+}
 
-// También forzar inicialización por si acaso
-window.addEventListener('load', inicializarSistema);
-
+document.addEventListener('DOMContentLoaded', initializeSystem);

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -1,0 +1,150 @@
+import { state } from './state.js';
+
+function getElement(id) {
+    return document.getElementById(id);
+}
+
+function createCell(text) {
+    const cell = document.createElement('td');
+    cell.className = 'px-6 py-4 whitespace-nowrap';
+    cell.textContent = text;
+    return cell;
+}
+
+function escapeAttributeValue(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+export function renderSearchResults(mantenimientos, { onEdit, onDelete }) {
+    const tabla = getElement('tabla-resultados');
+    const container = getElement('resultados-busqueda');
+    if (!tabla || !container) {
+        return;
+    }
+
+    state.mantenimientos = Array.isArray(mantenimientos) ? mantenimientos : [];
+
+    tabla.innerHTML = '';
+
+    if (!state.mantenimientos.length) {
+        const emptyRow = document.createElement('tr');
+        const emptyCell = document.createElement('td');
+        emptyCell.colSpan = 5;
+        emptyCell.className = 'px-6 py-4 text-center';
+        emptyCell.textContent = 'No se encontraron resultados';
+        emptyRow.appendChild(emptyCell);
+        tabla.appendChild(emptyRow);
+        container.classList.remove('hidden');
+        return;
+    }
+
+    state.mantenimientos.forEach(mantenimiento => {
+        const fila = document.createElement('tr');
+        fila.appendChild(createCell(mantenimiento.Cliente || 'N/A'));
+        fila.appendChild(createCell(mantenimiento.Fecha_Servicio || 'N/A'));
+        fila.appendChild(createCell(mantenimiento.Tecnico_Asignado || 'N/A'));
+        fila.appendChild(createCell(mantenimiento.Modelo_Equipo || 'N/A'));
+
+        const acciones = document.createElement('td');
+        acciones.className = 'px-6 py-4 whitespace-nowrap';
+
+        const editBtn = document.createElement('button');
+        editBtn.type = 'button';
+        editBtn.className = 'text-blue-600 hover:text-blue-900 mr-2';
+        editBtn.textContent = 'Editar';
+        editBtn.addEventListener('click', () => onEdit(mantenimiento));
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.type = 'button';
+        deleteBtn.className = 'text-red-600 hover:text-red-900';
+        deleteBtn.textContent = 'Eliminar';
+        deleteBtn.addEventListener('click', () => onDelete(mantenimiento));
+
+        acciones.appendChild(editBtn);
+        acciones.appendChild(deleteBtn);
+        fila.appendChild(acciones);
+
+        tabla.appendChild(fila);
+    });
+
+    container.classList.remove('hidden');
+}
+
+export function clearSearchResults() {
+    const tabla = getElement('tabla-resultados');
+    if (tabla) {
+        tabla.innerHTML = '';
+    }
+    const container = getElement('resultados-busqueda');
+    if (container) {
+        container.classList.add('hidden');
+    }
+    state.mantenimientos = [];
+}
+
+export function openEditModal(mantenimiento) {
+    const modal = getElement('modal-edicion');
+    const formulario = getElement('formulario-edicion');
+
+    if (!modal || !formulario) {
+        return;
+    }
+
+    state.mantenimientoEditando = mantenimiento;
+
+    formulario.innerHTML = `
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">Cliente</label>
+                <input type="text" id="edit-cliente" value="${escapeAttributeValue(mantenimiento.Cliente || '')}" class="w-full border-gray-300 rounded-md p-2">
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">Fecha Servicio</label>
+                <input type="date" id="edit-fecha" value="${escapeAttributeValue(mantenimiento.Fecha_Servicio || '')}" class="w-full border-gray-300 rounded-md p-2">
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">Técnico</label>
+                <input type="text" id="edit-tecnico" value="${escapeAttributeValue(mantenimiento.Tecnico_Asignado || '')}" class="w-full border-gray-300 rounded-md p-2">
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">Próximo Mantenimiento</label>
+                <input type="date" id="edit-proximo-mant" value="${escapeAttributeValue(mantenimiento.Proximo_Mantenimiento || '')}" class="w-full border-gray-300 rounded-md p-2">
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">Conductividad Permeado</label>
+                <input type="number" id="edit-cond-perm" value="${escapeAttributeValue(mantenimiento.Conductividad_Permeado_Left || 0)}" class="w-full border-gray-300 rounded-md p-2">
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">Resumen</label>
+                <textarea id="edit-resumen" rows="3" class="w-full border-gray-300 rounded-md p-2">${escapeAttributeValue(mantenimiento.Resumen_Recomendaciones || '')}</textarea>
+            </div>
+        </div>
+        <input type="hidden" id="edit-id" value="${escapeAttributeValue(mantenimiento.ID_Unico || '')}">
+    `;
+
+    modal.classList.remove('hidden');
+}
+
+export function closeEditModal() {
+    const modal = getElement('modal-edicion');
+    if (modal) {
+        modal.classList.add('hidden');
+    }
+    state.mantenimientoEditando = null;
+}
+
+export function getEditFormValues() {
+    return {
+        id: getElement('edit-id')?.value || '',
+        cliente: getElement('edit-cliente')?.value || '',
+        fecha_servicio: getElement('edit-fecha')?.value || '',
+        tecnico_asignado: getElement('edit-tecnico')?.value || '',
+        proximo_mantenimiento: getElement('edit-proximo-mant')?.value || '',
+        conductividad_permeado_left: getElement('edit-cond-perm')?.value || 0,
+        resumen_recomendaciones: getElement('edit-resumen')?.value || '',
+    };
+}

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -1,0 +1,4 @@
+export const state = {
+    mantenimientos: [],
+    mantenimientoEditando: null,
+};


### PR DESCRIPTION
## Summary
- rename the maintenance dashboard page to `mprobajomesadaOHM2.html` and wire it to the new module loader
- split the large inline script into focused modules for configuration, API access, forms, dashboard rendering, shared state, and search/edit UI helpers
- rebuild `main.js` to orchestrate initialization, tab routing, and event handlers using the modularized code

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8815ee5348326a367ace7cf17044f