### PR TITLE
Configuración externa para API_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # reportesOBM
+
 Control de MP de osmosis bajo mesada
+
+## Configuración de la API
+
+La aplicación requiere la URL del backend para poder guardar y consultar los mantenimientos. Por seguridad, la URL no se deja codificada en el repositorio. Configúrala de una de las siguientes maneras:
+
+- **Configuración en tiempo de ejecución (recomendada):** Antes de cargar `public/js/main.js`, define la variable global `window.__APP_CONFIG__`.
+
+  ```html
+  <script>
+    window.__APP_CONFIG__ = {
+      API_URL: 'https://tu-api.example.com',
+    };
+  </script>
+  <script type="module" src="public/js/main.js"></script>
+  ```
+
+- **Variable de entorno:** expón la variable `API_URL` en el entorno que sirva la aplicación. El archivo `public/js/config.js` la detectará cuando exista un objeto `process.env` (por ejemplo en un empaquetado server-side).
+
+Si ninguna de las opciones anteriores está configurada, la aplicación mostrará una advertencia en la consola y las llamadas a la API fallarán.

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -1,6 +1,10 @@
 import { API_URL } from './config.js';
 
 async function postJSON(payload) {
+    if (!API_URL) {
+        throw new Error('API_URL no está configurada.');
+    }
+
     const response = await fetch(API_URL, {
         method: 'POST',
         headers: {
@@ -47,6 +51,10 @@ export async function eliminarMantenimiento(id) {
 }
 
 export async function obtenerDashboard() {
+    if (!API_URL) {
+        throw new Error('API_URL no está configurada.');
+    }
+
     const response = await fetch(`${API_URL}?action=dashboard`);
     const result = await response.json();
 

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -1,4 +1,19 @@
-export const API_URL = 'https://script.google.com/macros/s/AKfycbwcgwPPAxcSzK9RywqySXV0z4MVihaEbcIwdz4_UJDxNjre9s3ZNX2dCQA3l6lBEzO1Xw/exec';
+const runtimeConfig = typeof window !== 'undefined' ? window.__APP_CONFIG__ : undefined;
 
+const browserApiUrl = runtimeConfig && typeof runtimeConfig.API_URL === 'string'
+    ? runtimeConfig.API_URL.trim()
+    : '';
+
+let resolvedApiUrl = browserApiUrl;
+
+if (!resolvedApiUrl && typeof process !== 'undefined' && process.env && typeof process.env.API_URL === 'string') {
+    resolvedApiUrl = process.env.API_URL;
+}
+
+if (!resolvedApiUrl) {
+    console.warn('[config] API_URL no está configurada. Define window.__APP_CONFIG__.API_URL o la variable de entorno API_URL.');
+}
+
+export const API_URL = resolvedApiUrl;
 export const LMIN_TO_LPH = 60;
 export const LMIN_TO_GPD = (60 * 24) / 3.78541;

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,7 +1,14 @@
+import { API_URL } from './config.js';
 import { guardarMantenimiento, buscarMantenimientos, actualizarMantenimiento, eliminarMantenimiento, obtenerDashboard } from './api.js';
 import { renderDashboard } from './dashboard.js';
 import { generateReportNumber, getFormData, initializeForm, resetForm, setReportNumber } from './forms.js';
 import { clearSearchResults, getEditFormValues, openEditModal, closeEditModal, renderSearchResults } from './search.js';
+
+const isApiConfigured = typeof API_URL === 'string' && API_URL.length > 0;
+
+if (!isApiConfigured) {
+    console.warn('API_URL no configurado. Configura window.__APP_CONFIG__.API_URL o la variable de entorno API_URL.');
+}
 
 function showTab(tabName) {
     document.querySelectorAll('.tab-content').forEach(tab => tab.classList.add('hidden'));


### PR DESCRIPTION
## Summary
- tomar la URL de la API desde `window.__APP_CONFIG__` o una variable de entorno para evitar exponer credenciales en el repositorio
- avisar desde `config.js` y `main.js` cuando falta la configuración de la API
- documentar en el README cómo definir `API_URL` antes de cargar la aplicación

## Testing
- no se ejecutaron pruebas (no hay suites definidas)


------
https://chatgpt.com/codex/tasks/task_e_68c88807b5248326849db75b3ef7b254