### PR TITLE
Add linting and formatting configuration

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,35 +1,12 @@
 module.exports = {
-    root: true,
-    env: {
-        browser: true,
-        es2022: true,
-    },
-    extends: ['eslint:recommended'],
-    parserOptions: {
-        ecmaVersion: 'latest',
-        sourceType: 'module',
-    },
-    globals: {
-        process: 'readonly',
-        Chart: 'readonly',
-    },
-    ignorePatterns: ['dist/', 'node_modules/'],
-    rules: {
-        'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^ignored' }],
-        'no-console': 'off',
-    },
-    overrides: [
-        {
-            files: ['*.config.js', 'postcss.config.js', 'tailwind.config.js', 'vite.config.js'],
-            env: {
-                node: true,
-            },
-        },
-        {
-            files: ['scripts/**/*.js'],
-            env: {
-                node: true,
-            },
-        },
-    ],
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: ['eslint:recommended'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  rules: {},
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "tabWidth": 2
+}

--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -6,8 +6,18 @@ const browserApiUrl = runtimeConfig && typeof runtimeConfig.API_URL === 'string'
 
 let resolvedApiUrl = browserApiUrl;
 
-if (!resolvedApiUrl && typeof process !== 'undefined' && process.env && typeof process.env.API_URL === 'string') {
-    resolvedApiUrl = process.env.API_URL;
+const runtimeProcess =
+    typeof globalThis !== 'undefined' && typeof globalThis.process === 'object'
+        ? globalThis.process
+        : undefined;
+
+if (
+    !resolvedApiUrl &&
+    runtimeProcess &&
+    runtimeProcess.env &&
+    typeof runtimeProcess.env.API_URL === 'string'
+) {
+    resolvedApiUrl = runtimeProcess.env.API_URL;
 }
 
 if (!resolvedApiUrl) {

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -1,3 +1,5 @@
+/* global Chart */
+
 let chartMensual = null;
 let chartTecnicos = null;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "autoprefixer": "^10.4.17",
         "eslint": "^8.57.1",
         "postcss": "^8.4.38",
+        "prettier": "^3.2.5",
         "tailwindcss": "^3.4.3",
         "vite": "^5.2.0"
       }
@@ -2740,6 +2741,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint ."
+    "lint": "eslint \"frontend/js/**/*.js\"",
+    "format": "prettier --write \"frontend/js/**/*.{js,json,css,html}\""
   },
   "devDependencies": {
     "autoprefixer": "^10.4.17",
     "eslint": "^8.57.1",
+    "prettier": "^3.2.5",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",
     "vite": "^5.2.0"


### PR DESCRIPTION
## Summary
- simplify the ESLint configuration to target the browser and modern JavaScript
- add a Prettier configuration and expose lint/format npm scripts
- resolve lint issues in the configuration and dashboard modules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8a47372f4832688109113c1ec4c36