### PR TITLE
Use script properties for Apps Script configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,14 @@ Los módulos se cargan desde `mprobajomesadaOHM2.html` mediante `<script type="m
    Numero_Reporte, Timestamp, ID_Unico
    ```
 3. Anota el ID del documento (la cadena entre `/d/` y `/edit` en la URL del Sheet).
-4. Si necesitas múltiples hojas dentro del mismo documento, asegúrate de que la pestaña que actuará como base de datos coincida con el valor de `SHEET_NAME` definido en el script.
+4. Si necesitas múltiples hojas dentro del mismo documento, asegúrate de que la pestaña que actuará como base de datos coincida con el valor que cargarás en la propiedad `SHEET_NAME` del proyecto de Apps Script.
 
 ### 2. Configurar el proyecto de Apps Script
 1. Abre la hoja y navega a **Extensiones > Apps Script**.
 2. Copia el contenido de [`scripts/gestor.gs`](scripts/gestor.gs) en el editor.
-3. Sustituye los valores de las constantes iniciales:
-   ```javascript
-   const SHEET_ID = 'TU_ID_DE_HOJA';
-   const SHEET_NAME = 'Nombre de pestaña';
-   ```
+3. Define las propiedades del script `SHEET_ID` y `SHEET_NAME`:
+   - Abre **Project Settings** (icono de engranaje en la barra lateral). En la sección **Script properties**, pulsa **Add script property** y crea las claves `SHEET_ID` (con el ID del documento de Google Sheets) y `SHEET_NAME` (con el nombre exacto de la pestaña que actuará como base de datos).
+   - Como alternativa, edita la función `initProperties()` incluida al inicio de `gestor.gs` con tus valores y ejecútala una vez desde **Run > Run function > initProperties**. Esto almacenará ambos campos en las propiedades del script; posteriormente puedes volver a dejar la función con valores genéricos si lo prefieres.
 4. Guarda el proyecto (por ejemplo `Gestor Reportes OBM`).
 
 ### 3. Publicar la API

--- a/scripts/gestor.gs
+++ b/scripts/gestor.gs
@@ -1,5 +1,16 @@
-const SHEET_ID = '14_6UyAhZQqHz6EGMRhr7YyqQ-KHMBsjeU4M5a_SRhis'; // REEMPLAZA ESTO con el ID de tu Google Sheet
-const SHEET_NAME = 'Hoja 1';
+const SCRIPT_PROPERTIES = PropertiesService.getScriptProperties();
+const SHEET_ID = SCRIPT_PROPERTIES.getProperty('SHEET_ID');
+const SHEET_NAME = SCRIPT_PROPERTIES.getProperty('SHEET_NAME');
+
+function initProperties() {
+  PropertiesService.getScriptProperties().setProperties(
+    {
+      SHEET_ID: 'TU_ID_DE_HOJA',
+      SHEET_NAME: 'Nombre de pestaña'
+    },
+    true
+  );
+}
 
 const CAMPOS_ACTUALIZABLES = [
   'Cliente', 'Fecha_Servicio', 'Direccion', 'Tecnico_Asignado', 'Modelo_Equipo',
@@ -19,7 +30,19 @@ const CAMPOS_ACTUALIZABLES = [
 
 const SheetRepository = {
   getSheet() {
-    return SpreadsheetApp.openById(SHEET_ID).getSheetByName(SHEET_NAME);
+    if (!SHEET_ID || !SHEET_NAME) {
+      throw new Error(
+        'Configura las propiedades de script SHEET_ID y SHEET_NAME antes de ejecutar la API.'
+      );
+    }
+
+    const sheet = SpreadsheetApp.openById(SHEET_ID).getSheetByName(SHEET_NAME);
+
+    if (!sheet) {
+      throw new Error(`No se encontró la hoja ${SHEET_NAME} en el documento configurado.`);
+    }
+
+    return sheet;
   },
   getSheetData() {
     const sheet = this.getSheet();


### PR DESCRIPTION
## Summary
- read the sheet configuration from Apps Script properties instead of hardcoded constants and add an `initProperties` helper with validation
- document how to configure `SHEET_ID` and `SHEET_NAME` via script properties in the Apps Script editor

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8a970f4988326b39c1af105262c34