### PR TITLE
feat: add authentication and audit metadata

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,12 +10,20 @@
 </head>
 <body class="bg-gray-100">
     <div class="container mx-auto p-4 md:p-8 max-w-7xl">
-        <header class="flex justify-between items-center mb-8 no-print">
+        <header class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-8 no-print">
             <div>
                 <h1 class="text-3xl font-bold text-gray-800">Sistema de Gestión de Mantenimientos RO</h1>
                 <p class="text-gray-600 mt-2">ID del Protocolo: PMA-RO-RES-12</p>
             </div>
-            <img src="../OHM-agua.png" alt="Logo OHM Agua" class="max-w-[180px] h-auto">
+            <div class="flex items-center justify-between md:justify-end gap-4 w-full md:w-auto">
+                <div id="auth-user-panel" class="hidden flex-col items-start md:items-end text-sm text-gray-600">
+                    <span id="current-user" class="font-semibold text-gray-700"></span>
+                    <button id="logout-button" type="button" class="text-blue-600 hover:text-blue-800 hover:underline text-sm mt-1" disabled>
+                        Cerrar sesión
+                    </button>
+                </div>
+                <img src="../OHM-agua.png" alt="Logo OHM Agua" class="max-w-[180px] h-auto">
+            </div>
         </header>
 
         <div class="print-header">
@@ -226,7 +234,7 @@
             </div>
 
             <!-- Modal de Edición -->
-            <div id="modal-edicion" class="fixed inset-0 bg-gray-600 bg-opacity-50 hidden flex items-center justify-center p-4 z-50">
+            <div id="modal-edicion" class="fixed inset-0 bg-gray-600 bg-opacity-50 hidden flex items-center justify-center p-4 z-40">
                 <div class="bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-screen overflow-y-auto">
                     <div class="p-6">
                         <h3 class="text-xl font-semibold mb-4">Editar Mantenimiento</h3>
@@ -291,6 +299,29 @@
                         </tbody>
                     </table>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="login-modal" class="fixed inset-0 bg-gray-900 bg-opacity-60 hidden flex items-center justify-center p-4 z-50">
+        <div class="bg-white rounded-lg shadow-xl w-full max-w-md">
+            <div class="p-6 space-y-4">
+                <h2 class="text-2xl font-semibold text-gray-800">Iniciar sesión</h2>
+                <p class="text-sm text-gray-600">Ingresa tu usuario registrado y el token de acceso otorgado por el administrador.</p>
+                <form id="login-form" class="space-y-4">
+                    <div>
+                        <label for="login-usuario" class="block text-sm font-medium text-gray-700 mb-1">Usuario</label>
+                        <input id="login-usuario" name="usuario" type="text" autocomplete="username" class="w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+                    </div>
+                    <div>
+                        <label for="login-token" class="block text-sm font-medium text-gray-700 mb-1">Token</label>
+                        <input id="login-token" name="token" type="password" autocomplete="current-password" class="w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+                    </div>
+                    <p id="login-error" class="text-sm text-red-600 hidden"></p>
+                    <button type="submit" class="w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
+                        Ingresar
+                    </button>
+                </form>
             </div>
         </div>
     </div>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -1,8 +1,15 @@
 import { API_URL } from './config.js';
+import { getAuthPayload } from './auth.js';
 
-async function postJSON(payload) {
+async function postJSON(payload, { requireAuth = true } = {}) {
     if (!API_URL) {
         throw new Error('API_URL no está configurada.');
+    }
+
+    const requestPayload = { ...payload };
+
+    if (requireAuth) {
+        Object.assign(requestPayload, getAuthPayload());
     }
 
     let response;
@@ -12,7 +19,7 @@ async function postJSON(payload) {
             headers: {
                 'Content-Type': 'text/plain; charset=utf-8',
             },
-            body: JSON.stringify(payload),
+            body: JSON.stringify(requestPayload),
         });
     } catch (error) {
         if (error?.name === 'AbortError') {
@@ -73,16 +80,7 @@ export async function eliminarMantenimiento(id) {
 }
 
 export async function obtenerDashboard() {
-    if (!API_URL) {
-        throw new Error('API_URL no está configurada.');
-    }
-
-    const response = await fetch(`${API_URL}?action=dashboard`);
-    const result = await response.json();
-
-    if (result.result !== 'success') {
-        throw new Error(result.error || 'Error desconocido');
-    }
-
-    return result.data;
+    return postJSON({
+        action: 'dashboard',
+    });
 }

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -1,0 +1,352 @@
+import { API_URL } from './config.js';
+
+const STORAGE_KEY = 'reportesOBM.auth';
+
+let cachedAuth = null;
+let listenersBound = false;
+let pendingAuth = null;
+
+function getStorage() {
+    if (typeof window !== 'undefined' && window.localStorage) {
+        return window.localStorage;
+    }
+    if (typeof globalThis !== 'undefined' && globalThis.localStorage) {
+        return globalThis.localStorage;
+    }
+    return null;
+}
+
+function loadStoredAuth() {
+    if (cachedAuth) {
+        return cachedAuth;
+    }
+
+    const storage = getStorage();
+    if (!storage) {
+        return null;
+    }
+
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) {
+        return null;
+    }
+
+    try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object') {
+            const token = typeof parsed.token === 'string' ? parsed.token : '';
+            const usuario = typeof parsed.usuario === 'string' ? parsed.usuario : '';
+            if (token && usuario) {
+                cachedAuth = { token, usuario };
+                return cachedAuth;
+            }
+        }
+    } catch (error) {
+        console.warn('[auth] No se pudo leer la sesión almacenada:', error);
+    }
+
+    return null;
+}
+
+function persistAuth(auth) {
+    cachedAuth = auth;
+    const storage = getStorage();
+    if (storage) {
+        storage.setItem(STORAGE_KEY, JSON.stringify(auth));
+    }
+    updateUserPanel(auth);
+}
+
+function clearStoredAuth() {
+    cachedAuth = null;
+    const storage = getStorage();
+    if (storage) {
+        storage.removeItem(STORAGE_KEY);
+    }
+    updateUserPanel(null);
+}
+
+function getElements() {
+    if (typeof document === 'undefined') {
+        return {};
+    }
+
+    return {
+        modal: document.getElementById('login-modal'),
+        form: document.getElementById('login-form'),
+        error: document.getElementById('login-error'),
+        usuarioInput: document.getElementById('login-usuario'),
+        tokenInput: document.getElementById('login-token'),
+        logoutButton: document.getElementById('logout-button'),
+        panel: document.getElementById('auth-user-panel'),
+        userLabel: document.getElementById('current-user'),
+    };
+}
+
+function showLoginModal() {
+    const { modal, error, usuarioInput } = getElements();
+    if (modal) {
+        modal.classList.remove('hidden');
+    }
+    if (error) {
+        error.textContent = '';
+        error.classList.add('hidden');
+    }
+    if (usuarioInput) {
+        usuarioInput.focus();
+    }
+}
+
+function hideLoginModal() {
+    const { modal, form, error } = getElements();
+    if (modal) {
+        modal.classList.add('hidden');
+    }
+    if (form) {
+        form.reset();
+    }
+    if (error) {
+        error.textContent = '';
+        error.classList.add('hidden');
+    }
+}
+
+function setFormLoading(form, isLoading) {
+    if (!form) {
+        return;
+    }
+    const inputs = form.querySelectorAll('input');
+    inputs.forEach(input => {
+        input.disabled = isLoading;
+    });
+
+    const submitButton = form.querySelector('button[type="submit"]');
+    if (submitButton) {
+        if (isLoading) {
+            submitButton.dataset.originalText = submitButton.textContent;
+            submitButton.textContent = 'Ingresando...';
+            submitButton.disabled = true;
+        } else {
+            submitButton.textContent = submitButton.dataset.originalText || 'Ingresar';
+            submitButton.disabled = false;
+            delete submitButton.dataset.originalText;
+        }
+    }
+}
+
+function displayError(message) {
+    const { error } = getElements();
+    if (!error) {
+        return;
+    }
+    error.textContent = message;
+    error.classList.remove('hidden');
+}
+
+function updateUserPanel(auth) {
+    const { panel, userLabel, logoutButton } = getElements();
+    if (!panel || !userLabel || !logoutButton) {
+        return;
+    }
+
+    if (auth && auth.usuario) {
+        userLabel.textContent = `Sesión activa: ${auth.usuario}`;
+        panel.classList.remove('hidden');
+        logoutButton.disabled = false;
+    } else {
+        userLabel.textContent = '';
+        panel.classList.add('hidden');
+        logoutButton.disabled = true;
+    }
+}
+
+function createPendingAuthPromise() {
+    if (pendingAuth) {
+        return pendingAuth.promise;
+    }
+
+    let resolveFn;
+    let rejectFn;
+    const promise = new Promise((resolve, reject) => {
+        resolveFn = resolve;
+        rejectFn = reject;
+    });
+
+    pendingAuth = {
+        promise,
+        resolve: resolveFn,
+        reject: rejectFn,
+    };
+
+    return promise;
+}
+
+function resolvePendingAuth(usuario) {
+    if (pendingAuth && typeof pendingAuth.resolve === 'function') {
+        pendingAuth.resolve(usuario);
+    }
+    pendingAuth = null;
+}
+
+async function requestAuthentication({ usuario, token }) {
+    if (!API_URL) {
+        throw new Error('API_URL no está configurada.');
+    }
+
+    const payload = {
+        action: 'login',
+        usuario: typeof usuario === 'string' ? usuario.trim() : '',
+        token: typeof token === 'string' ? token.trim() : '',
+    };
+
+    let response;
+    try {
+        response = await fetch(API_URL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'text/plain; charset=utf-8',
+            },
+            body: JSON.stringify(payload),
+        });
+    } catch (error) {
+        if (error?.name === 'AbortError') {
+            throw new Error('La solicitud de autenticación excedió el tiempo de espera.');
+        }
+        if (error instanceof TypeError) {
+            throw new Error('No se pudo conectar con el servidor de autenticación.');
+        }
+        throw new Error(error?.message || 'Error inesperado al iniciar sesión.');
+    }
+
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+    }
+
+    let result;
+    try {
+        result = await response.json();
+    } catch (error) {
+        throw new Error('No se pudo interpretar la respuesta de autenticación.');
+    }
+
+    if (result.result !== 'success') {
+        throw new Error(result.error || 'Credenciales inválidas.');
+    }
+
+    const data = result.data || {};
+    const resolvedUser = typeof data.usuario === 'string' && data.usuario.trim()
+        ? data.usuario.trim()
+        : payload.usuario;
+
+    if (!resolvedUser) {
+        throw new Error('La respuesta del servidor no incluye el usuario autenticado.');
+    }
+
+    return {
+        token: payload.token,
+        usuario: resolvedUser,
+    };
+}
+
+async function handleLoginSubmit(event) {
+    event.preventDefault();
+
+    const { form, tokenInput, usuarioInput } = getElements();
+    if (!form || !(form instanceof HTMLFormElement)) {
+        return;
+    }
+
+    const token = tokenInput?.value || '';
+    const usuario = usuarioInput?.value || '';
+
+    if (!token.trim() || !usuario.trim()) {
+        displayError('Completa el usuario y el token de acceso.');
+        return;
+    }
+
+    setFormLoading(form, true);
+    try {
+        const auth = await requestAuthentication({ token, usuario });
+        persistAuth(auth);
+        hideLoginModal();
+        resolvePendingAuth(auth.usuario);
+    } catch (error) {
+        displayError(error?.message || 'No se pudo iniciar sesión.');
+    } finally {
+        setFormLoading(form, false);
+    }
+}
+
+function handleLogout(event) {
+    if (event) {
+        event.preventDefault();
+    }
+    clearStoredAuth();
+    showLoginModal();
+    createPendingAuthPromise();
+}
+
+function bindEventListeners() {
+    if (listenersBound) {
+        return;
+    }
+
+    const { form, logoutButton } = getElements();
+    if (form) {
+        form.addEventListener('submit', handleLoginSubmit);
+    }
+    if (logoutButton) {
+        logoutButton.addEventListener('click', handleLogout);
+    }
+
+    listenersBound = true;
+}
+
+export function getAuthPayload() {
+    const auth = loadStoredAuth();
+    if (!auth || !auth.token || !auth.usuario) {
+        throw new Error('Sesión no autenticada. Vuelve a iniciar sesión.');
+    }
+    return { token: auth.token, usuario: auth.usuario };
+}
+
+export async function initializeAuth() {
+    bindEventListeners();
+
+    const existingAuth = loadStoredAuth();
+    if (existingAuth && existingAuth.token && existingAuth.usuario) {
+        try {
+            const auth = await requestAuthentication(existingAuth);
+            persistAuth(auth);
+            hideLoginModal();
+            return auth.usuario;
+        } catch (error) {
+            console.warn('[auth] Sesión almacenada inválida:', error);
+            clearStoredAuth();
+        }
+    }
+
+    showLoginModal();
+    return createPendingAuthPromise();
+}
+
+export function logout() {
+    handleLogout();
+}
+
+export async function requireAuthentication() {
+    try {
+        const auth = getAuthPayload();
+        return auth.usuario;
+    } catch (error) {
+        showLoginModal();
+        return createPendingAuthPromise();
+    }
+}
+
+export const __testables__ = {
+    loadStoredAuth,
+    persistAuth,
+    clearStoredAuth,
+    requestAuthentication,
+};

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -1,4 +1,5 @@
 import { API_URL } from './config.js';
+import { initializeAuth } from './auth.js';
 import { guardarMantenimiento, buscarMantenimientos, actualizarMantenimiento, eliminarMantenimiento, obtenerDashboard } from './api.js';
 import { renderDashboard } from './dashboard.js';
 import { generateReportNumber, getFormData, initializeForm, resetForm, setReportNumber } from './forms.js';
@@ -200,11 +201,17 @@ function attachEventListeners() {
     }
 }
 
-function initializeSystem() {
+async function initializeSystem() {
+    await initializeAuth();
     renderComponentStages();
     initializeForm();
     attachEventListeners();
     showTab('nuevo');
 }
 
-document.addEventListener('DOMContentLoaded', initializeSystem);
+document.addEventListener('DOMContentLoaded', () => {
+    initializeSystem().catch(error => {
+        console.error('Error inicializando la aplicación:', error);
+        alert('No se pudo inicializar la aplicación. Revisa la consola para más detalles.');
+    });
+});


### PR DESCRIPTION
## Summary
- add a frontend auth module with login modal and token storage
- include auth data on every API call and validate tokens in gestor.gs while storing the editor in Actualizado_por
- document the new AUTHORIZED_USERS configuration and update unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8ab63ab688326a0af80ab8eb7f570