### PR TITLE
Add clientes listing endpoint to Apps Script backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,17 @@ Los módulos se cargan desde `frontend/index.html` mediante `<script type="modul
    ```
 3. Anota el ID del documento (la cadena entre `/d/` y `/edit` en la URL del Sheet).
 4. Si necesitas múltiples hojas dentro del mismo documento, asegúrate de que la pestaña que actuará como base de datos coincida con el valor que cargarás en la propiedad `SHEET_NAME` del proyecto de Apps Script.
+5. Crea una pestaña adicional para el directorio de clientes (por defecto se espera `clientes`) con los encabezados:
+   ```text
+   Nombre, Direccion, Telefono, Mail, CUIT
+   ```
+   Cada fila debe contener los datos normalizados del cliente que quieras exponer a través de la API.
 
 ### 2. Configurar el proyecto de Apps Script
 1. Abre la hoja y navega a **Extensiones > Apps Script**.
 2. Copia el contenido de [`scripts/gestor.gs`](scripts/gestor.gs) en el editor.
-3. Define las propiedades del script `SHEET_ID`, `SHEET_NAME` y `AUTHORIZED_USERS`:
-   - Abre **Project Settings** (icono de engranaje en la barra lateral). En la sección **Script properties**, pulsa **Add script property** y crea las claves `SHEET_ID` (con el ID del documento de Google Sheets) y `SHEET_NAME` (con el nombre exacto de la pestaña que actuará como base de datos).
+3. Define las propiedades del script `SHEET_ID`, `SHEET_NAME`, `CLIENTES_SHEET_NAME` y `AUTHORIZED_USERS`:
+   - Abre **Project Settings** (icono de engranaje en la barra lateral). En la sección **Script properties**, pulsa **Add script property** y crea las claves `SHEET_ID` (con el ID del documento de Google Sheets), `SHEET_NAME` (con el nombre exacto de la pestaña que actúa como base de datos principal) y `CLIENTES_SHEET_NAME` (con el nombre de la pestaña que contiene el padrón de clientes; si usas el valor por defecto basta con indicar `clientes`).
    - Añade la propiedad `AUTHORIZED_USERS` con un JSON que mapee los tokens válidos, por ejemplo: `[{"usuario": "tecnico@example.com", "token": "token-seguro"}]`. Cada entrada puede asociar explícitamente un token con el nombre del usuario que lo utilizará.
    - Como alternativa, edita la función `initProperties()` incluida al inicio de `gestor.gs` con tus valores y ejecútala una vez desde **Run > Run function > initProperties**. Esto almacenará los campos en las propiedades del script; posteriormente puedes volver a dejar la función con valores genéricos si lo prefieres.
 4. Guarda el proyecto (por ejemplo `Gestor Reportes OBM`).


### PR DESCRIPTION
## Summary
- add constants and helpers to read the clientes sheet with normalized records
- expose a clientes action in the Apps Script API that reuses authentication and sorts the list
- document the required clientes tab and script properties in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cab7c05f2483268cebbb8ffefb1b6a