### PR TITLE
Use default JSON import for Vite config version

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,7 @@
 import { defineConfig } from 'vite';
+import pkg from './package.json' assert { type: 'json' };
+
+const version = pkg.version;
 
 export default defineConfig({
     root: 'frontend',


### PR DESCRIPTION
## Summary
- import `package.json` using a default JSON import in `vite.config.js`
- derive a `version` constant from the package metadata so existing references remain intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb028ef2ec8326a8e7f1070fa35d72