### PR TITLE
Fix package version import in Vite config

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,7 @@
             <div>
                 <h1 class="text-3xl font-bold text-gray-800">Sistema de Gestión de Mantenimientos RO</h1>
                 <p class="text-gray-600 mt-2">ID del Protocolo: PMA-RO-RES-12</p>
+                <span id="app-version" class="text-xs text-gray-500 font-semibold"></span>
             </div>
             <div class="flex items-center justify-between md:justify-end gap-4 w-full md:w-auto">
                 <div id="auth-user-panel" class="hidden flex-col items-start md:items-end text-sm text-gray-600">

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -1,3 +1,4 @@
+/* global __APP_VERSION__ */
 import { API_URL } from './config.js';
 import { initializeAuth } from './auth.js';
 import { guardarMantenimiento, buscarMantenimientos, actualizarMantenimiento, eliminarMantenimiento, obtenerDashboard, obtenerClientes } from './api.js';
@@ -10,6 +11,25 @@ const isApiConfigured = typeof API_URL === 'string' && API_URL.length > 0;
 
 if (!isApiConfigured) {
     console.warn('API_URL no configurado. Configura window.__APP_CONFIG__.API_URL o la variable de entorno API_URL.');
+}
+
+function showAppVersion() {
+    const versionElement = document.getElementById('app-version');
+    if (!versionElement) {
+        return;
+    }
+
+    if (typeof __APP_VERSION__ !== 'undefined') {
+        const versionValue = `${__APP_VERSION__}`.trim();
+        if (versionValue) {
+            versionElement.textContent = `Versión ${versionValue}`;
+            versionElement.classList.remove('hidden');
+            return;
+        }
+    }
+
+    versionElement.textContent = '';
+    versionElement.classList.add('hidden');
 }
 
 function showTab(tabName) {
@@ -233,6 +253,7 @@ async function initializeSystem() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    showAppVersion();
     initializeSystem().catch(error => {
         console.error('Error inicializando la aplicación:', error);
         alert('No se pudo inicializar la aplicación. Revisa la consola para más detalles.');

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,8 @@
 import { defineConfig } from 'vite';
+import pkg from './package.json' assert { type: 'json' };
+
+const version = pkg.version;
+const appVersion = typeof version === 'string' ? version : '';
 
 export default defineConfig({
     root: 'frontend',
@@ -12,5 +16,8 @@ export default defineConfig({
         fs: {
             allow: ['..'],
         },
+    },
+    define: {
+        __APP_VERSION__: JSON.stringify(appVersion),
     },
 });


### PR DESCRIPTION
## Summary
- switch the Vite configuration to import `package.json` using a default JSON module export
- keep exposing `__APP_VERSION__` by reusing the normalized package version value

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cafce267b883268058c098e20354e2