### PR TITLE
Ensure locked client inputs are disabled and update form cards

### DIFF
--- a/frontend/css/styles.build.css
+++ b/frontend/css/styles.build.css
@@ -612,6 +612,215 @@ video {
   }
 }
 
+.tab-button {
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-color: transparent;
+  background-color: rgb(255 255 255 / 0.8);
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 600;
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+}
+
+.tab-button:hover {
+  --tw-translate-y: -0.125rem;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  --tw-border-opacity: 1;
+  border-color: rgb(191 219 254 / var(--tw-border-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(37 99 235 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.tab-button:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity, 1));
+  --tw-ring-offset-width: 2px;
+}
+
+.tab-button.active {
+  --tw-border-opacity: 1;
+  border-color: rgb(37 99 235 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.tab-button.active:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(29 78 216 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(29 78 216 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+.action-button {
+  display: inline-flex;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-color: transparent;
+  background-color: rgb(255 255 255 / 0.9);
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  padding-top: 0.625rem;
+  padding-bottom: 0.625rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 600;
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+}
+
+.action-button:hover {
+  --tw-translate-y: -0.125rem;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.action-button:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-offset-width: 2px;
+}
+
+.action-button.reset-btn {
+  --tw-bg-opacity: 1;
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+}
+
+.action-button.reset-btn:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(209 213 219 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
+}
+
+.action-button.reset-btn:focus-visible {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(156 163 175 / var(--tw-ring-opacity, 1));
+}
+
+.action-button.print-btn {
+  --tw-bg-opacity: 1;
+  background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+.action-button.print-btn:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(29 78 216 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+.action-button.print-btn:focus-visible {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(59 130 246 / var(--tw-ring-opacity, 1));
+}
+
+.client-detail-empty {
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+}
+
+.client-detail-empty::-moz-placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-placeholder-opacity, 1));
+}
+
+.client-detail-empty::placeholder {
+  --tw-placeholder-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-placeholder-opacity, 1));
+}
+
+.client-detail-locked {
+  cursor: not-allowed;
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+}
+
+.section-card > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+}
+
+.section-card {
+  border-radius: 1rem;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+  padding: 1.5rem;
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.section-card h2 {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 600;
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
+}
+
+.section-card .guide-text {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+}
+
 .fixed {
   position: fixed;
 }
@@ -770,6 +979,10 @@ video {
   gap: 0.25rem;
 }
 
+.gap-2 {
+  gap: 0.5rem;
+}
+
 .gap-4 {
   gap: 1rem;
 }
@@ -814,10 +1027,22 @@ video {
   margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.25rem * var(--tw-space-y-reverse));
+}
+
 .space-y-4 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+}
+
+.space-y-6 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
 }
 
 .divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -855,12 +1080,21 @@ video {
   border-radius: 0.375rem;
 }
 
+.rounded-xl {
+  border-radius: 0.75rem;
+}
+
 .border {
   border-width: 1px;
 }
 
 .border-t {
   border-top-width: 1px;
+}
+
+.border-gray-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
 }
 
 .border-gray-300 {
@@ -1055,6 +1289,12 @@ video {
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+.shadow-sm {
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .shadow-xl {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1,3 +1,81 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+    .tab-button {
+        @apply px-4 py-2 text-sm font-semibold text-gray-600 rounded-lg border border-transparent bg-white/80 shadow-sm transform transition-all duration-150 ease-out;
+    }
+
+    .tab-button:hover {
+        @apply -translate-y-0.5 shadow-md text-blue-600 border-blue-200;
+    }
+
+    .tab-button:focus-visible {
+        @apply outline-none ring-2 ring-offset-2 ring-blue-400;
+    }
+
+    .tab-button.active {
+        @apply bg-blue-600 text-white border-blue-600 shadow-md;
+    }
+
+    .tab-button.active:hover {
+        @apply bg-blue-700 text-white border-blue-700;
+    }
+
+    .action-button {
+        @apply inline-flex items-center justify-center px-5 py-2.5 rounded-lg font-semibold text-sm border border-transparent bg-white/90 text-gray-700 transform transition-all duration-150 ease-out shadow-sm;
+    }
+
+    .action-button:hover {
+        @apply -translate-y-0.5 shadow-md;
+    }
+
+    .action-button:focus-visible {
+        @apply outline-none ring-2 ring-offset-2;
+    }
+
+    .action-button.reset-btn {
+        @apply bg-gray-200 text-gray-700;
+    }
+
+    .action-button.reset-btn:hover {
+        @apply bg-gray-300 text-gray-800;
+    }
+
+    .action-button.reset-btn:focus-visible {
+        @apply ring-gray-400;
+    }
+
+    .action-button.print-btn {
+        @apply bg-blue-600 text-white;
+    }
+
+    .action-button.print-btn:hover {
+        @apply bg-blue-700 text-white;
+    }
+
+    .action-button.print-btn:focus-visible {
+        @apply ring-blue-500;
+    }
+
+    .client-detail-empty {
+        @apply bg-gray-100 text-gray-600 placeholder-gray-400;
+    }
+
+    .client-detail-locked {
+        @apply bg-gray-50 text-gray-700 cursor-not-allowed;
+    }
+
+    .section-card {
+        @apply bg-white rounded-2xl border border-gray-200 shadow-sm p-6 space-y-6;
+    }
+
+    .section-card h2 {
+        @apply text-2xl font-semibold text-gray-800;
+    }
+
+    .section-card .guide-text {
+        @apply text-sm text-gray-600;
+    }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -47,67 +47,87 @@
             <form id="maintenance-form">
                 <!-- Sección A: Datos del Servicio y del Equipo -->
                 <div class="form-section" id="section-a">
-                    <h2>A. Datos del Servicio y del Equipo</h2>
-                    <p class="guide-text">Complete la información para identificar el servicio y el equipo.</p>
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
-                        <div class="input-group flex flex-col gap-1">
-                            <label for="cliente" class="font-semibold text-gray-700">Cliente:</label>
-                            <select id="cliente" name="cliente" class="w-full border border-gray-300 rounded px-3 py-2">
-                                <option value="" disabled selected>Selecciona un cliente</option>
-                            </select>
+                    <div class="section-card">
+                        <div class="space-y-1">
+                            <h2>A. Datos del Servicio y del Equipo</h2>
+                            <p class="guide-text">Complete la información para identificar el servicio y el equipo.</p>
                         </div>
-                        <div class="input-group flex flex-col gap-1">
-                            <label for="cliente_telefono" class="font-semibold text-gray-700">Teléfono:</label>
-                            <input type="text" id="cliente_telefono" value="" readonly data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
-                        </div>
-                        <div class="input-group flex flex-col gap-1">
-                            <label for="cliente_email" class="font-semibold text-gray-700">Email:</label>
-                            <input type="text" id="cliente_email" value="" readonly data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
-                        </div>
-                        <div class="input-group flex flex-col gap-1">
-                            <label for="cliente_cuit" class="font-semibold text-gray-700">CUIT:</label>
-                            <input type="text" id="cliente_cuit" value="" readonly data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
-                        </div>
-                        <div class="input-group flex flex-col gap-1">
-                            <label for="fecha_display" class="font-semibold text-gray-700">Fecha del Servicio:</label>
-                            <input type="text" id="fecha_display" readonly data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
-                            <input type="hidden" id="fecha" name="fecha">
-                        </div>
-                        <div class="input-group flex flex-col gap-1">
-                            <label for="direccion" class="font-semibold text-gray-700">Dirección:</label>
-                            <input type="text" id="direccion" name="direccion" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
-                        </div>
-                        <div class="input-group flex flex-col gap-1">
-                            <label for="tecnico" class="font-semibold text-gray-700">Técnico Asignado:</label>
-                            <input type="text" id="tecnico" name="tecnico" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
-                        </div>
-                        <div class="input-group flex flex-col gap-1">
-                            <label for="modelo" class="font-semibold text-gray-700">Modelo del Equipo:</label>
-                            <input type="text" id="modelo" name="modelo" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
-                        </div>
-                        <div class="input-group flex flex-col gap-1">
-                            <label for="id_interna" class="font-semibold text-gray-700">ID Interna / Activo N°:</label>
-                            <input type="text" id="id_interna" name="id_interna" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
-                        </div>
-                        <div class="input-group flex flex-col gap-1">
-                            <label for="n_serie" class="font-semibold text-gray-700">Número de Serie:</label>
-                            <input type="text" id="n_serie" name="n_serie" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
-                        </div>
-                        <div class="input-group flex flex-col gap-1">
-                            <label for="proximo_mant" class="font-semibold text-gray-700">Próximo Mantenimiento:</label>
-                            <input type="date" id="proximo_mant" name="proximo_mant" class="w-full border border-gray-300 rounded px-3 py-2">
+                        <div class="space-y-6">
+                            <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-6">
+                                <div class="flex flex-col gap-2 mb-4 md:flex-row md:items-center md:justify-between">
+                                    <h3 class="text-xl font-semibold text-gray-800">Datos del Cliente</h3>
+                                    <p class="text-sm text-gray-500">Selecciona un cliente para completar los datos automáticamente.</p>
+                                </div>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+                                    <div class="input-group flex flex-col gap-1">
+                                        <label for="cliente" class="font-semibold text-gray-700">Cliente:</label>
+                                        <select id="cliente" name="cliente" class="w-full border border-gray-300 rounded px-3 py-2">
+                                            <option value="" disabled selected>Selecciona un cliente</option>
+                                        </select>
+                                    </div>
+                                    <div class="input-group flex flex-col gap-1">
+                                        <label for="direccion" class="font-semibold text-gray-700">Dirección:</label>
+                                        <input type="text" id="direccion" name="direccion" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
+                                    </div>
+                                    <div class="input-group flex flex-col gap-1">
+                                        <label for="cliente_telefono" class="font-semibold text-gray-700">Teléfono:</label>
+                                        <input type="text" id="cliente_telefono" value="" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
+                                    </div>
+                                    <div class="input-group flex flex-col gap-1">
+                                        <label for="cliente_email" class="font-semibold text-gray-700">Email:</label>
+                                        <input type="text" id="cliente_email" value="" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
+                                    </div>
+                                    <div class="input-group flex flex-col gap-1">
+                                        <label for="cliente_cuit" class="font-semibold text-gray-700">CUIT:</label>
+                                        <input type="text" id="cliente_cuit" value="" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="rounded-xl border border-gray-200 bg-white shadow-sm p-6">
+                                <h3 class="text-xl font-semibold text-gray-800 mb-4">Datos del Servicio y del Equipo</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+                                    <div class="input-group flex flex-col gap-1">
+                                        <label for="fecha_display" class="font-semibold text-gray-700">Fecha del Servicio:</label>
+                                        <input type="text" id="fecha_display" readonly data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
+                                        <input type="hidden" id="fecha" name="fecha">
+                                    </div>
+                                    <div class="input-group flex flex-col gap-1">
+                                        <label for="tecnico" class="font-semibold text-gray-700">Técnico Asignado:</label>
+                                        <input type="text" id="tecnico" name="tecnico" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
+                                    </div>
+                                    <div class="input-group flex flex-col gap-1">
+                                        <label for="modelo" class="font-semibold text-gray-700">Modelo del Equipo:</label>
+                                        <input type="text" id="modelo" name="modelo" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
+                                    </div>
+                                    <div class="input-group flex flex-col gap-1">
+                                        <label for="id_interna" class="font-semibold text-gray-700">ID Interna / Activo N°:</label>
+                                        <input type="text" id="id_interna" name="id_interna" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
+                                    </div>
+                                    <div class="input-group flex flex-col gap-1">
+                                        <label for="n_serie" class="font-semibold text-gray-700">Número de Serie:</label>
+                                        <input type="text" id="n_serie" name="n_serie" data-auto-resize class="w-full border border-gray-300 rounded px-3 py-2">
+                                    </div>
+                                    <div class="input-group flex flex-col gap-1">
+                                        <label for="proximo_mant" class="font-semibold text-gray-700">Próximo Mantenimiento:</label>
+                                        <input type="date" id="proximo_mant" name="proximo_mant" class="w-full border border-gray-300 rounded px-3 py-2">
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
 
                 <!-- Sección B: Parámetros de Operación -->
                 <div class="form-section" id="section-b">
-                    <h2>B. Parámetros de Operación</h2>
-                    <p class="guide-text">Mida y registre los valores antes (As Found) y después (As Left) del mantenimiento. Cierre la válvula del tanque para medir presión y caudales de trabajo.</p>
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-x-6 gap-y-4 items-end">
-                        <div class="md:col-span-1 font-semibold text-gray-700">Parámetro</div>
-                        <div class="md:col-span-1 font-semibold text-gray-700 text-center">Estado Inicial ('As Found')</div>
-                        <div class="md:col-span-1 font-semibold text-gray-700 text-center">Estado Final ('As Left')</div>
+                    <div class="section-card">
+                        <div class="space-y-1">
+                            <h2>B. Parámetros de Operación</h2>
+                            <p class="guide-text">Mida y registre los valores antes (As Found) y después (As Left) del mantenimiento. Cierre la válvula del tanque para medir presión y caudales de trabajo.</p>
+                        </div>
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-x-6 gap-y-4 items-end">
+                            <div class="md:col-span-1 font-semibold text-gray-700">Parámetro</div>
+                            <div class="md:col-span-1 font-semibold text-gray-700 text-center">Estado Inicial ('As Found')</div>
+                            <div class="md:col-span-1 font-semibold text-gray-700 text-center">Estado Final ('As Left')</div>
 
                         <!-- Fugas -->
                         <label class="md:col-span-1">Fugas visibles</label>
@@ -175,48 +195,57 @@
                         <label class="md:col-span-1">Test Presostato Baja</label>
                         <div class="md:col-span-1"><select id="presostato_baja_found" name="presostato_baja_found" class="text-center w-full"><option value="N/A" selected>No Aplica</option><option value="Pasa">Pasa</option><option value="Falla">Falla</option></select></div>
                         <div class="md:col-span-1"><select id="presostato_baja_left" name="presostato_baja_left" class="text-center w-full"><option value="N/A" selected>No Aplica</option><option value="Pasa">Pasa</option><option value="Falla">Falla</option></select></div>
+                        </div>
                     </div>
                 </div>
 
                 <!-- Sección C: Registro de Componentes -->
                 <div class="form-section" id="section-c">
-                    <h2>C. Registro de Componentes y Sanitización</h2>
-                    <p class="guide-text">Marque la acción realizada para cada etapa en el sistema.</p>
-                     <div class="grid grid-cols-1 sm:grid-cols-6 gap-x-4 gap-y-2 items-center font-semibold text-gray-700 mb-2">
-                        <div class="sm:col-span-1">Etapa</div>
-                        <div class="sm:col-span-2">Detalles del Componente</div>
-                        <div class="sm:col-span-2">Acción</div>
-                    </div>
-                    <div id="component-stage-container"></div>
-
-                    <template id="component-stage-template">
-                        <div class="grid grid-cols-1 sm:grid-cols-6 gap-x-4 gap-y-2 items-center border-t py-2 component-stage">
-                            <div class="sm:col-span-1 stage-title"></div>
-                            <div class="sm:col-span-2">
-                                <input type="text" class="w-full stage-details">
-                            </div>
-                            <div class="sm:col-span-2 flex space-x-4 stage-actions"></div>
+                    <div class="section-card">
+                        <div class="space-y-1">
+                            <h2>C. Registro de Componentes y Sanitización</h2>
+                            <p class="guide-text">Marque la acción realizada para cada etapa en el sistema.</p>
                         </div>
-                    </template>
-                    <!-- Sanitización -->
-                    <hr class="my-4">
-                    <div class="grid grid-cols-1 sm:grid-cols-6 gap-x-4 gap-y-2 items-center py-2">
-                        <div class="sm:col-span-3 font-semibold text-gray-700">Sanitización del Sistema</div>
-                        <div class="sm:col-span-2">
-                            <select id="sanitizacion_status" name="sanitizacion" class="w-full">
-                                <option value="N/A" selected>No Aplica</option>
-                                <option value="Realizada">Realizada</option>
-                                <option value="No Realizada">No Realizada</option>
-                            </select>
+                        <div class="grid grid-cols-1 sm:grid-cols-6 gap-x-4 gap-y-2 items-center font-semibold text-gray-700 mb-2">
+                            <div class="sm:col-span-1">Etapa</div>
+                            <div class="sm:col-span-2">Detalles del Componente</div>
+                            <div class="sm:col-span-2">Acción</div>
+                        </div>
+                        <div id="component-stage-container"></div>
+
+                        <template id="component-stage-template">
+                            <div class="grid grid-cols-1 sm:grid-cols-6 gap-x-4 gap-y-2 items-center border-t py-2 component-stage">
+                                <div class="sm:col-span-1 stage-title"></div>
+                                <div class="sm:col-span-2">
+                                    <input type="text" class="w-full stage-details">
+                                </div>
+                                <div class="sm:col-span-2 flex space-x-4 stage-actions"></div>
+                            </div>
+                        </template>
+                        <!-- Sanitización -->
+                        <hr class="my-4">
+                        <div class="grid grid-cols-1 sm:grid-cols-6 gap-x-4 gap-y-2 items-center py-2">
+                            <div class="sm:col-span-3 font-semibold text-gray-700">Sanitización del Sistema</div>
+                            <div class="sm:col-span-2">
+                                <select id="sanitizacion_status" name="sanitizacion" class="w-full">
+                                    <option value="N/A" selected>No Aplica</option>
+                                    <option value="Realizada">Realizada</option>
+                                    <option value="No Realizada">No Realizada</option>
+                                </select>
+                            </div>
                         </div>
                     </div>
                 </div>
 
                 <!-- Sección D: Resumen -->
                 <div class="form-section" id="section-d">
-                    <h2>D. Resumen y Recomendaciones Finales</h2>
-                     <p class="guide-text">Anote un resumen claro del trabajo realizado y las recomendaciones para el cliente.</p>
-                    <textarea id="resumen" name="resumen" rows="6" class="w-full border-gray-300 rounded-md p-2 focus:border-blue-500 focus:ring focus:ring-blue-200" placeholder="Ej: Se realizó mantenimiento anual completo, reemplazando filtros de 1ª, 2ª y 5ª etapa. La presión de operación se normalizó de 2.5 a 4.5 bar. El equipo queda 100% operativo."></textarea>
+                    <div class="section-card">
+                        <div class="space-y-1">
+                            <h2>D. Resumen y Recomendaciones Finales</h2>
+                            <p class="guide-text">Anote un resumen claro del trabajo realizado y las recomendaciones para el cliente.</p>
+                        </div>
+                        <textarea id="resumen" name="resumen" rows="6" class="w-full border-gray-300 rounded-md p-2 focus:border-blue-500 focus:ring focus:ring-blue-200" placeholder="Ej: Se realizó mantenimiento anual completo, reemplazando filtros de 1ª, 2ª y 5ª etapa. La presión de operación se normalizó de 2.5 a 4.5 bar. El equipo queda 100% operativo."></textarea>
+                    </div>
                 </div>
 
                 <!-- Botones de Acción -->

--- a/frontend/js/__tests__/forms.test.js
+++ b/frontend/js/__tests__/forms.test.js
@@ -59,6 +59,25 @@ describe('serializeForm', () => {
         });
     });
 
+    test('incluye valores de inputs deshabilitados', () => {
+        document.body.innerHTML = `
+            <form id="test-form">
+                <input type="text" name="direccion" value="Calle 123" disabled />
+                <input type="text" name="nota" value="editable" />
+            </form>
+        `;
+
+        const form = document.getElementById('test-form');
+        const direccion = form.querySelector('input[name="direccion"]');
+
+        expect(direccion.disabled).toBe(true);
+
+        const data = serializeForm(form);
+
+        expect(data).toEqual({ direccion: 'Calle 123', nota: 'editable' });
+        expect(direccion.disabled).toBe(true);
+    });
+
     test('devuelve objeto vacío cuando el elemento no es un formulario', () => {
         expect(serializeForm(null)).toEqual({});
         expect(serializeForm(document.createElement('div'))).toEqual({});
@@ -172,6 +191,18 @@ describe('selección de clientes', () => {
         expect(document.getElementById('cliente_telefono').value).toBe('987654');
         expect(document.getElementById('cliente_email').value).toBe('dos@example.com');
         expect(document.getElementById('cliente_cuit').value).toBe('27-87654321-9');
+
+        const direccionInput = document.getElementById('direccion');
+        const telefonoInput = document.getElementById('cliente_telefono');
+        const emailInput = document.getElementById('cliente_email');
+        const cuitInput = document.getElementById('cliente_cuit');
+
+        [direccionInput, telefonoInput, emailInput, cuitInput].forEach(input => {
+            expect(input.readOnly).toBe(true);
+            expect(input.disabled).toBe(true);
+            expect(input.classList.contains('client-detail-locked')).toBe(true);
+            expect(input.classList.contains('client-detail-empty')).toBe(false);
+        });
     });
 
     test('maneja clientes con nombres duplicados sin identificadores visibles', () => {
@@ -199,6 +230,11 @@ describe('selección de clientes', () => {
         expect(document.getElementById('cliente_telefono').value).toBe('111111');
         expect(document.getElementById('cliente_email').value).toBe('uno@example.com');
         expect(document.getElementById('cliente_cuit').value).toBe('');
+        expect(document.getElementById('cliente_cuit').classList.contains('client-detail-empty')).toBe(true);
+        expect(document.getElementById('cliente_cuit').readOnly).toBe(false);
+        expect(document.getElementById('cliente_cuit').disabled).toBe(false);
+        expect(document.getElementById('direccion').readOnly).toBe(true);
+        expect(document.getElementById('direccion').disabled).toBe(true);
 
         select.selectedIndex = 2;
         expect(select.selectedIndex).toBe(2);
@@ -208,6 +244,11 @@ describe('selección de clientes', () => {
         expect(document.getElementById('cliente_telefono').value).toBe('222222');
         expect(document.getElementById('cliente_email').value).toBe('dos@example.com');
         expect(document.getElementById('cliente_cuit').value).toBe('');
+        expect(document.getElementById('cliente_cuit').classList.contains('client-detail-empty')).toBe(true);
+        expect(document.getElementById('cliente_cuit').readOnly).toBe(false);
+        expect(document.getElementById('cliente_cuit').disabled).toBe(false);
+        expect(document.getElementById('direccion').readOnly).toBe(true);
+        expect(document.getElementById('direccion').disabled).toBe(true);
     });
 
     test('resetForm limpia la selección y los campos de cliente', () => {
@@ -230,6 +271,9 @@ describe('selección de clientes', () => {
         expect(document.getElementById('cliente_telefono').value).toBe('');
         expect(document.getElementById('cliente_email').value).toBe('');
         expect(document.getElementById('cliente_cuit').value).toBe('');
+        expect(document.getElementById('direccion').readOnly).toBe(false);
+        expect(document.getElementById('direccion').classList.contains('client-detail-empty')).toBe(true);
+        expect(document.getElementById('direccion').disabled).toBe(false);
     });
 });
 

--- a/frontend/js/forms.js
+++ b/frontend/js/forms.js
@@ -145,7 +145,7 @@ function createClientDetails(cliente) {
     };
 }
 
-function refreshClientDetailFieldState(element, options = {}) {
+function refreshClientDetailFieldState(element, { lockWhenFilled = false } = {}) {
     if (!(element instanceof HTMLInputElement)) {
         return;
     }
@@ -154,12 +154,11 @@ function refreshClientDetailFieldState(element, options = {}) {
         return;
     }
 
-    const { lockWhenFilled } = options;
     const hasValue = normalizeStringValue(element.value) !== '';
-
     let shouldDisable = false;
-    if (typeof lockWhenFilled === 'boolean') {
-        shouldDisable = lockWhenFilled && hasValue;
+
+    if (lockWhenFilled) {
+        shouldDisable = hasValue;
     } else if (element.dataset[CLIENT_DETAIL_LOCKED_DATA_KEY] === 'true') {
         shouldDisable = hasValue;
     }


### PR DESCRIPTION
## Summary
- disable auto-rellened client inputs when locked while keeping empty fields editable and serialize disabled values
- extend the client form tests to cover disabled inputs and serialization of locked fields
- wrap each main form section in a reusable card container and style the headings and guidance text

## Testing
- npm run build:css
- npm test -- --runTestsByPath frontend/js/__tests__/forms.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cac4d46a108326b4cd4361c4e968e7