### PR TITLE
Apply card styling to main form sections

### DIFF
--- a/frontend/css/styles.build.css
+++ b/frontend/css/styles.build.css
@@ -612,6 +612,22 @@ video {
   }
 }
 
+.form-card > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+}
+
+.form-card {
+  border-radius: 0.75rem;
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+  padding: 1.5rem;
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .fixed {
   position: fixed;
 }

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+    .form-card {
+        @apply bg-white p-6 rounded-xl shadow-md space-y-4;
+    }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -45,7 +45,7 @@
         <div id="tab-nuevo" class="tab-content">
             <form id="maintenance-form">
                 <!-- Sección A: Datos del Servicio y del Equipo -->
-                <div class="form-section" id="section-a">
+                <div class="form-section form-card" id="section-a">
                     <h2>A. Datos del Servicio y del Equipo</h2>
                     <p class="guide-text">Complete la información para identificar el servicio y el equipo.</p>
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6">
@@ -65,7 +65,7 @@
                 </div>
 
                 <!-- Sección B: Parámetros de Operación -->
-                <div class="form-section" id="section-b">
+                <div class="form-section form-card" id="section-b">
                     <h2>B. Parámetros de Operación</h2>
                     <p class="guide-text">Mida y registre los valores antes (As Found) y después (As Left) del mantenimiento. Cierre la válvula del tanque para medir presión y caudales de trabajo.</p>
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-x-6 gap-y-4 items-end">
@@ -155,7 +155,7 @@
                 </div>
 
                 <!-- Sección C: Registro de Componentes -->
-                <div class="form-section" id="section-c">
+                <div class="form-section form-card" id="section-c">
                     <h2>C. Registro de Componentes y Sanitización</h2>
                     <p class="guide-text">Marque la acción realizada para cada etapa en el sistema.</p>
                      <div class="grid grid-cols-1 sm:grid-cols-6 gap-x-4 gap-y-2 items-center font-semibold text-gray-700 mb-2">
@@ -189,7 +189,7 @@
                 </div>
 
                 <!-- Sección D: Resumen -->
-                <div class="form-section" id="section-d">
+                <div class="form-section form-card" id="section-d">
                     <h2>D. Resumen y Recomendaciones Finales</h2>
                      <p class="guide-text">Anote un resumen claro del trabajo realizado y las recomendaciones para el cliente.</p>
                     <textarea id="resumen" name="resumen" rows="6" class="w-full border-gray-300 rounded-md p-2 focus:border-blue-500 focus:ring focus:ring-blue-200" placeholder="Ej: Se realizó mantenimiento anual completo, reemplazando filtros de 1ª, 2ª y 5ª etapa. La presión de operación se normalizó de 2.5 a 4.5 bar. El equipo queda 100% operativo."></textarea>


### PR DESCRIPTION
## Summary
- add a reusable `form-card` Tailwind component that applies white background, padding, rounded corners, shadow, and spacing
- apply the new card styling to sections A–D of the maintenance form and rebuild the compiled stylesheet

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68cb249e71b883268991dd6a135fbbef