### PR TITLE
Add component stage toggle control

### DIFF
--- a/frontend/css/styles.build.css
+++ b/frontend/css/styles.build.css
@@ -628,6 +628,88 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.component-toggle {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: stretch;
+  width: 100%;
+  border-radius: 9999px;
+  overflow: hidden;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: rgb(75 85 99);
+}
+
+.component-toggle__track {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background-color: rgb(229 231 235);
+  transition: background-color 0.2s ease;
+  z-index: 1;
+}
+
+.component-toggle__thumb {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 50%;
+  border-radius: inherit;
+  background-color: #ffffff;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+  transition: transform 0.25s ease;
+  z-index: 2;
+}
+
+.component-toggle[data-state="cambiado"] .component-toggle__thumb {
+  transform: translateX(0%);
+}
+
+.component-toggle[data-state="inspeccionado"] .component-toggle__thumb {
+  transform: translateX(100%);
+}
+
+.component-toggle__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
+}
+
+.component-toggle__option {
+  position: relative;
+  z-index: 5;
+  cursor: pointer;
+  padding: 0.75rem 0.5rem;
+  text-align: center;
+  color: rgb(107 114 128);
+  transition: color 0.2s ease, font-weight 0.2s ease;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.component-toggle__option:hover {
+  color: rgb(55 65 81);
+}
+
+.component-toggle[data-state="cambiado"] .component-toggle__option--cambiado,
+    .component-toggle[data-state="inspeccionado"] .component-toggle__option--inspeccionado {
+  color: rgb(17 24 39);
+  font-weight: 600;
+}
+
 .fixed {
   position: fixed;
 }

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -6,4 +6,84 @@
     .form-card {
         @apply bg-white p-6 rounded-xl shadow-md space-y-4;
     }
+
+    .component-toggle {
+        position: relative;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        align-items: stretch;
+        width: 100%;
+        border-radius: 9999px;
+        overflow: hidden;
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: rgb(75 85 99);
+    }
+
+    .component-toggle__track {
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background-color: rgb(229 231 235);
+        transition: background-color 0.2s ease;
+        z-index: 1;
+    }
+
+    .component-toggle__thumb {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 50%;
+        border-radius: inherit;
+        background-color: #ffffff;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+        transition: transform 0.25s ease;
+        z-index: 2;
+    }
+
+    .component-toggle[data-state="cambiado"] .component-toggle__thumb {
+        transform: translateX(0%);
+    }
+
+    .component-toggle[data-state="inspeccionado"] .component-toggle__thumb {
+        transform: translateX(100%);
+    }
+
+    .component-toggle__input {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        clip-path: inset(50%);
+        border: 0;
+        white-space: nowrap;
+    }
+
+    .component-toggle__option {
+        position: relative;
+        z-index: 5;
+        cursor: pointer;
+        padding: 0.75rem 0.5rem;
+        text-align: center;
+        color: rgb(107 114 128);
+        transition: color 0.2s ease, font-weight 0.2s ease;
+        user-select: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .component-toggle__option:hover {
+        color: rgb(55 65 81);
+    }
+
+    .component-toggle[data-state="cambiado"] .component-toggle__option--cambiado,
+    .component-toggle[data-state="inspeccionado"] .component-toggle__option--inspeccionado {
+        color: rgb(17 24 39);
+        font-weight: 600;
+    }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -171,7 +171,7 @@
                             <div class="sm:col-span-2">
                                 <input type="text" class="w-full stage-details">
                             </div>
-                            <div class="sm:col-span-2 flex space-x-4 stage-actions"></div>
+                            <div class="sm:col-span-2 stage-actions stage-actions--toggle"></div>
                         </div>
                     </template>
                     <!-- Sanitización -->

--- a/frontend/js/templates.js
+++ b/frontend/js/templates.js
@@ -1,8 +1,3 @@
-const COMPONENT_STAGE_ACTIONS = [
-    { value: 'Cambiado', label: 'Cambiado' },
-    { value: 'Inspeccionado', label: 'Inspeccionado', default: true },
-];
-
 const COMPONENT_STAGES = [
     {
         id: 'etapa1',
@@ -37,19 +32,56 @@ const COMPONENT_STAGES = [
     },
 ];
 
-function createActionLabel(stageId, action) {
-    const label = document.createElement('label');
-    const radio = document.createElement('input');
-    radio.type = 'radio';
-    radio.name = `${stageId}_accion`;
-    radio.value = action.value;
-    if (action.default) {
-        radio.checked = true;
-        radio.defaultChecked = true;
-    }
-    label.appendChild(radio);
-    label.appendChild(document.createTextNode(action.label));
-    return label;
+function createComponentToggle(stageId) {
+    const toggle = document.createElement('div');
+    toggle.className = 'component-toggle';
+    toggle.dataset.state = 'inspeccionado';
+
+    const changedId = `${stageId}_accion_cambiado`;
+    const inspectedId = `${stageId}_accion_inspeccionado`;
+
+    const changedInput = document.createElement('input');
+    changedInput.type = 'radio';
+    changedInput.name = `${stageId}_accion`;
+    changedInput.value = 'Cambiado';
+    changedInput.id = changedId;
+    changedInput.className = 'component-toggle__input';
+
+    const inspectedInput = document.createElement('input');
+    inspectedInput.type = 'radio';
+    inspectedInput.name = `${stageId}_accion`;
+    inspectedInput.value = 'Inspeccionado';
+    inspectedInput.id = inspectedId;
+    inspectedInput.className = 'component-toggle__input';
+    inspectedInput.checked = true;
+    inspectedInput.defaultChecked = true;
+
+    const track = document.createElement('div');
+    track.className = 'component-toggle__track';
+
+    const thumb = document.createElement('div');
+    thumb.className = 'component-toggle__thumb';
+    track.appendChild(thumb);
+
+    const changedLabel = document.createElement('label');
+    changedLabel.setAttribute('for', changedId);
+    changedLabel.className = 'component-toggle__option component-toggle__option--cambiado';
+    changedLabel.textContent = 'Cambiado';
+
+    const inspectedLabel = document.createElement('label');
+    inspectedLabel.setAttribute('for', inspectedId);
+    inspectedLabel.className = 'component-toggle__option component-toggle__option--inspeccionado';
+    inspectedLabel.textContent = 'Inspeccionado';
+
+    toggle.append(
+        changedInput,
+        inspectedInput,
+        track,
+        changedLabel,
+        inspectedLabel,
+    );
+
+    return toggle;
 }
 
 function populateStage(fragment, stage) {
@@ -70,11 +102,27 @@ function populateStage(fragment, stage) {
 
     const actionsContainer = fragment.querySelector('.stage-actions');
     if (actionsContainer) {
+        const toggle = createComponentToggle(stage.id);
         actionsContainer.innerHTML = '';
-        COMPONENT_STAGE_ACTIONS.forEach(action => {
-            const label = createActionLabel(stage.id, action);
-            actionsContainer.appendChild(label);
+        actionsContainer.appendChild(toggle);
+
+        const updateState = value => {
+            toggle.dataset.state = String(value).toLowerCase();
+        };
+
+        const radios = toggle.querySelectorAll('.component-toggle__input');
+        radios.forEach(radio => {
+            radio.addEventListener('change', () => {
+                if (radio.checked) {
+                    updateState(radio.value);
+                }
+            });
         });
+
+        const checkedRadio = toggle.querySelector('.component-toggle__input:checked');
+        if (checkedRadio) {
+            updateState(checkedRadio.value);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the component stage action labels with a single toggle slider and update the JavaScript helper accordingly
- adjust the stage template markup to host the new toggle element
- add custom styles for the toggle and rebuild the compiled stylesheet

## Testing
- npm run build:css
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb2707f95483269fa835d1dbf1789e