### PR TITLE
feat: redesign sanitizacion status control

### DIFF
--- a/frontend/css/styles.build.css
+++ b/frontend/css/styles.build.css
@@ -710,6 +710,99 @@ video {
   font-weight: 600;
 }
 
+.sanitizacion-options {
+  --sanitizacion-border: rgb(209 213 219);
+  --sanitizacion-background: rgb(249 250 251);
+  --sanitizacion-active-bg: rgb(229 231 235);
+  --sanitizacion-active-color: rgb(55 65 81);
+  --sanitizacion-active-border: rgba(107, 114, 128, 0.35);
+  --sanitizacion-active-shadow: rgba(55, 65, 81, 0.15);
+  display: flex;
+  width: 100%;
+  border-radius: 9999px;
+  border: 1px solid var(--sanitizacion-border);
+  background-color: var(--sanitizacion-background);
+  overflow: hidden;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sanitizacion-options[data-status="success"] {
+  --sanitizacion-border: rgb(134 239 172);
+  --sanitizacion-background: rgb(240 253 244);
+  --sanitizacion-active-bg: rgb(220 252 231);
+  --sanitizacion-active-color: rgb(22 101 52);
+  --sanitizacion-active-border: rgba(34, 197, 94, 0.45);
+  --sanitizacion-active-shadow: rgba(22, 101, 52, 0.25);
+}
+
+.sanitizacion-options[data-status="danger"] {
+  --sanitizacion-border: rgb(252 165 165);
+  --sanitizacion-background: rgb(254 242 242);
+  --sanitizacion-active-bg: rgb(254 226 226);
+  --sanitizacion-active-color: rgb(153 27 27);
+  --sanitizacion-active-border: rgba(248, 113, 113, 0.45);
+  --sanitizacion-active-shadow: rgba(153, 27, 27, 0.25);
+}
+
+.sanitizacion-options[data-status="neutral"] {
+  --sanitizacion-border: rgb(209 213 219);
+  --sanitizacion-background: rgb(249 250 251);
+  --sanitizacion-active-bg: rgb(229 231 235);
+  --sanitizacion-active-color: rgb(55 65 81);
+  --sanitizacion-active-border: rgba(107, 114, 128, 0.35);
+  --sanitizacion-active-shadow: rgba(55, 65, 81, 0.15);
+}
+
+.sanitizacion-option {
+  position: relative;
+  flex: 1 1 0%;
+}
+
+.sanitizacion-option input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.sanitizacion-option span {
+  display: block;
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  text-align: center;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: rgb(75 85 99);
+  border-left: 1px solid rgba(148, 163, 184, 0.25);
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+}
+
+.sanitizacion-option:first-child span {
+  border-left-color: transparent;
+}
+
+.sanitizacion-option input:not(:checked) + span:hover {
+  background-color: rgba(255, 255, 255, 0.6);
+  color: rgb(31 41 55);
+}
+
+.sanitizacion-option input:checked + span {
+  color: var(--sanitizacion-active-color);
+  background-color: var(--sanitizacion-active-bg);
+  border-color: var(--sanitizacion-active-border);
+  box-shadow: inset 0 0 0 1px var(--sanitizacion-active-border), 0 6px 18px -10px var(--sanitizacion-active-shadow);
+}
+
 .fixed {
   position: fixed;
 }

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -86,4 +86,95 @@
         color: rgb(17 24 39);
         font-weight: 600;
     }
+
+    .sanitizacion-options {
+        --sanitizacion-border: rgb(209 213 219);
+        --sanitizacion-background: rgb(249 250 251);
+        --sanitizacion-active-bg: rgb(229 231 235);
+        --sanitizacion-active-color: rgb(55 65 81);
+        --sanitizacion-active-border: rgba(107, 114, 128, 0.35);
+        --sanitizacion-active-shadow: rgba(55, 65, 81, 0.15);
+        display: flex;
+        width: 100%;
+        border-radius: 9999px;
+        border: 1px solid var(--sanitizacion-border);
+        background-color: var(--sanitizacion-background);
+        overflow: hidden;
+        box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
+        transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .sanitizacion-options[data-status="success"] {
+        --sanitizacion-border: rgb(134 239 172);
+        --sanitizacion-background: rgb(240 253 244);
+        --sanitizacion-active-bg: rgb(220 252 231);
+        --sanitizacion-active-color: rgb(22 101 52);
+        --sanitizacion-active-border: rgba(34, 197, 94, 0.45);
+        --sanitizacion-active-shadow: rgba(22, 101, 52, 0.25);
+    }
+
+    .sanitizacion-options[data-status="danger"] {
+        --sanitizacion-border: rgb(252 165 165);
+        --sanitizacion-background: rgb(254 242 242);
+        --sanitizacion-active-bg: rgb(254 226 226);
+        --sanitizacion-active-color: rgb(153 27 27);
+        --sanitizacion-active-border: rgba(248, 113, 113, 0.45);
+        --sanitizacion-active-shadow: rgba(153, 27, 27, 0.25);
+    }
+
+    .sanitizacion-options[data-status="neutral"] {
+        --sanitizacion-border: rgb(209 213 219);
+        --sanitizacion-background: rgb(249 250 251);
+        --sanitizacion-active-bg: rgb(229 231 235);
+        --sanitizacion-active-color: rgb(55 65 81);
+        --sanitizacion-active-border: rgba(107, 114, 128, 0.35);
+        --sanitizacion-active-shadow: rgba(55, 65, 81, 0.15);
+    }
+
+    .sanitizacion-option {
+        position: relative;
+        flex: 1 1 0%;
+    }
+
+    .sanitizacion-option input {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        clip-path: inset(50%);
+        white-space: nowrap;
+        border: 0;
+    }
+
+    .sanitizacion-option span {
+        display: block;
+        width: 100%;
+        padding: 0.6rem 0.75rem;
+        text-align: center;
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: rgb(75 85 99);
+        border-left: 1px solid rgba(148, 163, 184, 0.25);
+        transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+        user-select: none;
+    }
+
+    .sanitizacion-option:first-child span {
+        border-left-color: transparent;
+    }
+
+    .sanitizacion-option input:not(:checked) + span:hover {
+        background-color: rgba(255, 255, 255, 0.6);
+        color: rgb(31 41 55);
+    }
+
+    .sanitizacion-option input:checked + span {
+        color: var(--sanitizacion-active-color);
+        background-color: var(--sanitizacion-active-bg);
+        border-color: var(--sanitizacion-active-border);
+        box-shadow: inset 0 0 0 1px var(--sanitizacion-active-border), 0 6px 18px -10px var(--sanitizacion-active-shadow);
+    }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -179,11 +179,20 @@
                     <div class="grid grid-cols-1 sm:grid-cols-6 gap-x-4 gap-y-2 items-center py-2">
                         <div class="sm:col-span-3 font-semibold text-gray-700">Sanitización del Sistema</div>
                         <div class="sm:col-span-2">
-                            <select id="sanitizacion_status" name="sanitizacion" class="w-full">
-                                <option value="N/A" selected>No Aplica</option>
-                                <option value="Realizada">Realizada</option>
-                                <option value="No Realizada">No Realizada</option>
-                            </select>
+                            <div class="sanitizacion-options" data-status="neutral">
+                                <label class="sanitizacion-option" for="sanitizacion-realizada">
+                                    <input type="radio" id="sanitizacion-realizada" name="sanitizacion" value="Realizada">
+                                    <span>Realizada</span>
+                                </label>
+                                <label class="sanitizacion-option" for="sanitizacion-no-realizada">
+                                    <input type="radio" id="sanitizacion-no-realizada" name="sanitizacion" value="No Realizada">
+                                    <span>No Realizada</span>
+                                </label>
+                                <label class="sanitizacion-option" for="sanitizacion-na">
+                                    <input type="radio" id="sanitizacion-na" name="sanitizacion" value="N/A" checked>
+                                    <span>No Aplica</span>
+                                </label>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/frontend/js/forms.js
+++ b/frontend/js/forms.js
@@ -261,29 +261,65 @@ function configureConversionInputs() {
     });
 }
 
+const STATUS_SELECT_SELECTOR = 'select[id$="_found"], select[id$="_left"]';
+
 function setStatusColor(selectElement) {
     selectElement.classList.remove('status-pass', 'status-fail', 'status-na');
     const value = selectElement.value;
-    if (value === 'Pasa' || value === 'Realizada' || value === 'No') {
+    if (value === 'Pasa' || value === 'No') {
         selectElement.classList.add('status-pass');
-    } else if (value === 'Falla' || value === 'No Realizada' || value === 'Sí') {
+    } else if (value === 'Falla' || value === 'Sí') {
         selectElement.classList.add('status-fail');
     } else {
         selectElement.classList.add('status-na');
     }
 }
 
-function applyStatusColors() {
-    const statusSelects = document.querySelectorAll('select[id$="_found"], select[id$="_left"], select#sanitizacion_status');
+function applyStatusColorsToSelects() {
+    const statusSelects = document.querySelectorAll(STATUS_SELECT_SELECTOR);
     statusSelects.forEach(setStatusColor);
 }
 
 function configureStatusSelects() {
-    const statusSelects = document.querySelectorAll('select[id$="_found"], select[id$="_left"], select#sanitizacion_status');
+    const statusSelects = document.querySelectorAll(STATUS_SELECT_SELECTOR);
     statusSelects.forEach(select => {
         setStatusColor(select);
         select.addEventListener('change', () => setStatusColor(select));
     });
+}
+
+const SANITIZACION_STATUS_MAP = {
+    Realizada: 'success',
+    'No Realizada': 'danger',
+    'N/A': 'neutral',
+};
+
+function configureSanitizacionRadios() {
+    const container = document.querySelector('.sanitizacion-options');
+    if (!container) {
+        return;
+    }
+
+    const radios = container.querySelectorAll('input[type="radio"][name="sanitizacion"]');
+    if (!radios.length) {
+        container.dataset.status = 'neutral';
+        return;
+    }
+
+    const updateStatus = () => {
+        const checked = container.querySelector('input[type="radio"][name="sanitizacion"]:checked');
+        const statusKey = checked?.value || 'N/A';
+        container.dataset.status = SANITIZACION_STATUS_MAP[statusKey] || 'neutral';
+    };
+
+    if (!container.dataset.sanitizacionConfigured) {
+        radios.forEach(radio => {
+            radio.addEventListener('change', updateStatus);
+        });
+        container.dataset.sanitizacionConfigured = 'true';
+    }
+
+    updateStatus();
 }
 
 function configureNumberInputs() {
@@ -325,6 +361,7 @@ export function initializeForm() {
     configureNumberInputs();
     configureConversionInputs();
     configureStatusSelects();
+    configureSanitizacionRadios();
     calculateAll();
 }
 
@@ -336,7 +373,8 @@ export function resetForm() {
     setDefaultDate();
     clearDerivedFields();
     clearConversionOutputs();
-    applyStatusColors();
+    applyStatusColorsToSelects();
+    configureSanitizacionRadios();
 }
 
 export function getFormData() {


### PR DESCRIPTION
## Summary
- replace the sanitización select with a segmented radio group defaulted to "No Aplica"
- add Tailwind component styles for the sanitización options with status-driven colors and rebuild the compiled CSS
- update form helpers to manage the new radio set while keeping status color handling for other selects

## Testing
- npm run build:css
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb28845fd883268bae89b81f84cf7b