### PR TITLE
Add status styling and robust select color mapping

### DIFF
--- a/frontend/css/styles.build.css
+++ b/frontend/css/styles.build.css
@@ -628,6 +628,24 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.status-pass {
+  background-color: rgb(220 252 231);
+  color: rgb(22 101 52);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.status-fail {
+  background-color: rgb(254 226 226);
+  color: rgb(153 27 27);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.status-na {
+  background-color: rgb(229 231 235);
+  color: rgb(55 65 81);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
 .component-toggle {
   position: relative;
   display: grid;

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -7,6 +7,24 @@
         @apply bg-white p-6 rounded-xl shadow-md space-y-4;
     }
 
+    .status-pass {
+        background-color: rgb(220 252 231);
+        color: rgb(22 101 52);
+        transition: background-color 0.2s ease, color 0.2s ease;
+    }
+
+    .status-fail {
+        background-color: rgb(254 226 226);
+        color: rgb(153 27 27);
+        transition: background-color 0.2s ease, color 0.2s ease;
+    }
+
+    .status-na {
+        background-color: rgb(229 231 235);
+        color: rgb(55 65 81);
+        transition: background-color 0.2s ease, color 0.2s ease;
+    }
+
     .component-toggle {
         position: relative;
         display: grid;

--- a/frontend/js/forms.js
+++ b/frontend/js/forms.js
@@ -263,16 +263,24 @@ function configureConversionInputs() {
 
 const STATUS_SELECT_SELECTOR = 'select[id$="_found"], select[id$="_left"]';
 
+const STATUS_CLASS_BY_VALUE = {
+    pasa: 'status-pass',
+    no: 'status-pass',
+    falla: 'status-fail',
+    'no pasa': 'status-fail',
+    sí: 'status-fail',
+    si: 'status-fail',
+    'n/a': 'status-na',
+    'no aplica': 'status-na',
+    na: 'status-na',
+    '': 'status-na',
+};
+
 function setStatusColor(selectElement) {
     selectElement.classList.remove('status-pass', 'status-fail', 'status-na');
-    const value = selectElement.value;
-    if (value === 'Pasa' || value === 'No') {
-        selectElement.classList.add('status-pass');
-    } else if (value === 'Falla' || value === 'Sí') {
-        selectElement.classList.add('status-fail');
-    } else {
-        selectElement.classList.add('status-na');
-    }
+    const normalizedValue = String(selectElement.value ?? '').trim().toLowerCase();
+    const statusClass = STATUS_CLASS_BY_VALUE[normalizedValue] || 'status-na';
+    selectElement.classList.add(statusClass);
 }
 
 function applyStatusColorsToSelects() {


### PR DESCRIPTION
## Summary
- add .status-pass, .status-fail and .status-na component styles with soft background and contrasting text colors
- normalize select values to map Pasa/No/Sí/Falla/No Pasa/No Aplica options onto the new status classes for visual feedback

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cb370417348326b27227784055f754