### PR TITLE
feat: improve auth user menu

### DIFF
--- a/frontend/js/__tests__/auth.test.js
+++ b/frontend/js/__tests__/auth.test.js
@@ -51,25 +51,229 @@ const createClassList = initial => {
     };
 };
 
+const matchesSelector = (element, selector) => {
+    if (!element || !selector) {
+        return false;
+    }
+
+    const selectors = selector.split(',').map(token => token.trim()).filter(Boolean);
+    return selectors.some(sel => {
+        if (!sel) {
+            return false;
+        }
+        if (sel.startsWith('.')) {
+            const className = sel.slice(1);
+            return Boolean(element.classList?.contains(className));
+        }
+        if (sel.startsWith('#')) {
+            return element.id === sel.slice(1);
+        }
+        if (sel.startsWith('[') && sel.endsWith(']')) {
+            const content = sel.slice(1, -1);
+            const [attrNamePart, attrValuePart] = content.split('=');
+            const attrName = attrNamePart.trim();
+            const normalizedValue = attrValuePart?.trim()?.replace(/^['"]|['"]$/g, '');
+
+            let value = element.getAttribute?.(attrName);
+            if (value === undefined && attrName.startsWith('data-') && element.dataset) {
+                const dataKey = attrName
+                    .slice(5)
+                    .replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+                if (Object.prototype.hasOwnProperty.call(element.dataset, dataKey)) {
+                    value = element.dataset[dataKey];
+                }
+            }
+
+            if (attrValuePart === undefined) {
+                return value !== undefined;
+            }
+            return value === normalizedValue;
+        }
+        return false;
+    });
+};
+
+const createElementStub = ({ initialClasses = [], textContent = '', disabled = false } = {}) => {
+    const attributes = {};
+    const dataset = {};
+    const listeners = {};
+
+    const element = {
+        disabled,
+        textContent,
+        classList: createClassList(initialClasses),
+        dataset,
+        attributes,
+        listeners,
+        addEventListener: jest.fn((type, handler) => {
+            if (!listeners[type]) {
+                listeners[type] = new Set();
+            }
+            listeners[type].add(handler);
+        }),
+        removeEventListener: jest.fn((type, handler) => {
+            if (listeners[type]) {
+                listeners[type].delete(handler);
+            }
+        }),
+        dispatchEvent: jest.fn(event => {
+            const type = event?.type;
+            if (!type || !listeners[type]) {
+                return;
+            }
+            listeners[type].forEach(handler => {
+                handler(event);
+            });
+        }),
+        setAttribute: jest.fn((name, value) => {
+            attributes[name] = String(value);
+            if (name.startsWith('data-')) {
+                const dataKey = name
+                    .slice(5)
+                    .replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+                dataset[dataKey] = String(value);
+            }
+            if (name === 'role') {
+                element.role = String(value);
+            }
+        }),
+        getAttribute: jest.fn(name => {
+            if (Object.prototype.hasOwnProperty.call(attributes, name)) {
+                return attributes[name];
+            }
+            if (name.startsWith('data-')) {
+                const dataKey = name
+                    .slice(5)
+                    .replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+                if (Object.prototype.hasOwnProperty.call(dataset, dataKey)) {
+                    return dataset[dataKey];
+                }
+            }
+            return undefined;
+        }),
+        focus: jest.fn(),
+    };
+
+    element.children = [];
+    element.appendChild = child => {
+        element.children.push(child);
+        if (child && typeof child === 'object') {
+            child.parentElement = element;
+        }
+    };
+
+    element.contains = jest.fn(target => {
+        if (!target) {
+            return false;
+        }
+        if (target === element) {
+            return true;
+        }
+        return element.children.some(child => (typeof child?.contains === 'function'
+            ? child.contains(target)
+            : child === target));
+    });
+
+    element.querySelectorAll = jest.fn(selector => {
+        const results = [];
+        const visit = node => {
+            if (!node) {
+                return;
+            }
+            if (node !== element && matchesSelector(node, selector)) {
+                results.push(node);
+            }
+            if (Array.isArray(node.children)) {
+                node.children.forEach(visit);
+            }
+        };
+        element.children.forEach(visit);
+        return results;
+    });
+
+    element.querySelector = jest.fn(selector => element.querySelectorAll(selector)[0] || null);
+
+    return element;
+};
+
 const setupDocumentMock = () => {
-    const panel = { classList: createClassList(['hidden']) };
-    const userLabel = { textContent: '' };
-    const logoutButton = { disabled: true };
+    const panel = createElementStub({ initialClasses: ['hidden'] });
+    panel.id = 'auth-user-panel';
+
+    const menuButton = createElementStub();
+    menuButton.id = 'user-menu-toggle';
+    menuButton.disabled = true;
+    menuButton.setAttribute('aria-expanded', 'false');
+
+    const menu = createElementStub({ initialClasses: ['hidden'] });
+    menu.id = 'user-menu';
+    menu.setAttribute('aria-hidden', 'true');
+
+    const userNameDisplay = createElementStub();
+    userNameDisplay.setAttribute('data-user-name', '');
+
+    const helpLink = createElementStub();
+    helpLink.textContent = 'Ayuda';
+    helpLink.setAttribute('role', 'menuitem');
+    helpLink.setAttribute('data-auth-action', 'help');
+
+    const settingsLink = createElementStub();
+    settingsLink.textContent = 'Configuración';
+    settingsLink.setAttribute('role', 'menuitem');
+    settingsLink.setAttribute('data-auth-action', 'settings');
+
+    const logoutButton = createElementStub();
+    logoutButton.id = 'logout-button';
+    logoutButton.disabled = true;
+    logoutButton.setAttribute('role', 'menuitem');
+
+    menu.appendChild(userNameDisplay);
+    menu.appendChild(helpLink);
+    menu.appendChild(settingsLink);
+    menu.appendChild(logoutButton);
+
+    panel.appendChild(menuButton);
+    panel.appendChild(menu);
+
+    const docListeners = {};
 
     const elements = {
         panel,
-        userLabel,
+        menuButton,
+        menu,
+        userNameDisplay,
+        helpLink,
+        settingsLink,
         logoutButton,
     };
 
     const map = {
         'auth-user-panel': panel,
-        'current-user': userLabel,
+        'user-menu-toggle': menuButton,
+        'user-menu': menu,
         'logout-button': logoutButton,
+        'login-modal': null,
+        'login-form': null,
+        'login-error': null,
+        'login-usuario': null,
+        'login-token': null,
     };
 
     global.document = {
         getElementById: jest.fn(id => map[id] || null),
+        addEventListener: jest.fn((type, handler) => {
+            if (!docListeners[type]) {
+                docListeners[type] = new Set();
+            }
+            docListeners[type].add(handler);
+        }),
+        removeEventListener: jest.fn((type, handler) => {
+            if (docListeners[type]) {
+                docListeners[type].delete(handler);
+            }
+        }),
+        dispatchEvent: jest.fn(() => true),
+        __listeners: docListeners,
     };
 
     return elements;
@@ -110,7 +314,11 @@ describe('auth helpers', () => {
             expect(storage.setItem).toHaveBeenCalledWith(AUTH_STORAGE_KEY, JSON.stringify(auth));
             expect(loadStoredAuth()).toEqual(auth);
             expect(elements.panel.classList.contains('hidden')).toBe(false);
-            expect(elements.userLabel.textContent).toBe('Ana');
+            expect(elements.menuButton.disabled).toBe(false);
+            expect(elements.menuButton.getAttribute('aria-expanded')).toBe('false');
+            expect(elements.menu.classList.contains('hidden')).toBe(true);
+            expect(elements.menu.getAttribute('aria-hidden')).toBe('true');
+            expect(elements.userNameDisplay.textContent).toBe('Ana');
             expect(elements.logoutButton.disabled).toBe(false);
         });
 
@@ -123,6 +331,7 @@ describe('auth helpers', () => {
             expect(storage.setItem).not.toHaveBeenCalled();
             expect(loadStoredAuth()).toEqual(auth);
             expect(elements.panel.classList.contains('hidden')).toBe(false);
+            expect(elements.menuButton.disabled).toBe(false);
         });
     });
 
@@ -140,7 +349,11 @@ describe('auth helpers', () => {
             expect(storage.__store[AUTH_STORAGE_KEY]).toBeUndefined();
             expect(loadStoredAuth()).toBeNull();
             expect(elements.panel.classList.contains('hidden')).toBe(true);
-            expect(elements.userLabel.textContent).toBe('');
+            expect(elements.menuButton.disabled).toBe(true);
+            expect(elements.menuButton.getAttribute('aria-expanded')).toBe('false');
+            expect(elements.menu.classList.contains('hidden')).toBe(true);
+            expect(elements.menu.getAttribute('aria-hidden')).toBe('true');
+            expect(elements.userNameDisplay.textContent).toBe('');
             expect(elements.logoutButton.disabled).toBe(true);
         });
 
@@ -149,14 +362,114 @@ describe('auth helpers', () => {
             const { clearStoredAuth } = await getTestables();
 
             elements.panel.classList.remove('hidden');
+            elements.menuButton.disabled = false;
+            elements.menuButton.setAttribute('aria-expanded', 'true');
+            elements.menu.classList.remove('hidden');
+            elements.menu.setAttribute('aria-hidden', 'false');
             elements.logoutButton.disabled = false;
-            elements.userLabel.textContent = 'Demo';
+            elements.userNameDisplay.textContent = 'Demo';
 
             expect(() => clearStoredAuth()).not.toThrow();
             expect(storage.removeItem).not.toHaveBeenCalled();
             expect(elements.panel.classList.contains('hidden')).toBe(true);
             expect(elements.logoutButton.disabled).toBe(true);
-            expect(elements.userLabel.textContent).toBe('');
+            expect(elements.menuButton.disabled).toBe(true);
+            expect(elements.menuButton.getAttribute('aria-expanded')).toBe('false');
+            expect(elements.menu.classList.contains('hidden')).toBe(true);
+            expect(elements.menu.getAttribute('aria-hidden')).toBe('true');
+            expect(elements.userNameDisplay.textContent).toBe('');
+        });
+    });
+
+    describe('user menu interactions', () => {
+        test('abre y cierra el menú con el botón de usuario', async () => {
+            const { bindEventListeners, persistAuth } = await getTestables();
+            bindEventListeners();
+            persistAuth({ token: 'token-menu', usuario: 'Laura' });
+
+            const [buttonHandler] = Array.from(elements.menuButton.listeners.click);
+            expect(typeof buttonHandler).toBe('function');
+
+            const clickEvent = { preventDefault: jest.fn(), stopPropagation: jest.fn(), target: elements.menuButton };
+            buttonHandler(clickEvent);
+
+            expect(elements.menu.classList.contains('hidden')).toBe(false);
+            expect(elements.menu.getAttribute('aria-hidden')).toBe('false');
+            expect(elements.menuButton.getAttribute('aria-expanded')).toBe('true');
+            expect(global.document.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+            expect(global.document.addEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
+
+            buttonHandler(clickEvent);
+
+            expect(elements.menu.classList.contains('hidden')).toBe(true);
+            expect(elements.menuButton.getAttribute('aria-expanded')).toBe('false');
+            expect(global.document.removeEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+            expect(global.document.removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
+        });
+
+        test('cierra el menú al hacer clic fuera y al presionar Escape', async () => {
+            const { bindEventListeners, persistAuth } = await getTestables();
+            bindEventListeners();
+            persistAuth({ token: 'token-menu', usuario: 'Laura' });
+
+            const [buttonHandler] = Array.from(elements.menuButton.listeners.click);
+            const clickEvent = { preventDefault: jest.fn(), stopPropagation: jest.fn(), target: elements.menuButton };
+            buttonHandler(clickEvent);
+
+            expect(elements.menu.classList.contains('hidden')).toBe(false);
+
+            const [documentClickHandler] = Array.from(global.document.__listeners.click || []);
+            expect(typeof documentClickHandler).toBe('function');
+            documentClickHandler({ target: {} });
+
+            expect(elements.menu.classList.contains('hidden')).toBe(true);
+            expect(elements.menuButton.getAttribute('aria-expanded')).toBe('false');
+
+            buttonHandler(clickEvent);
+            expect(elements.menu.classList.contains('hidden')).toBe(false);
+
+            const [documentKeyHandler] = Array.from(global.document.__listeners.keydown || []);
+            expect(typeof documentKeyHandler).toBe('function');
+            documentKeyHandler({ key: 'Escape' });
+
+            expect(elements.menu.classList.contains('hidden')).toBe(true);
+            expect(elements.menuButton.focus).toHaveBeenCalled();
+        });
+
+        test('emite eventos de navegación para Ayuda y Configuración', async () => {
+            const { bindEventListeners, persistAuth } = await getTestables();
+            bindEventListeners();
+            persistAuth({ token: 'token-menu', usuario: 'Laura' });
+
+            const [buttonHandler] = Array.from(elements.menuButton.listeners.click);
+            const clickEvent = { preventDefault: jest.fn(), stopPropagation: jest.fn(), target: elements.menuButton };
+            buttonHandler(clickEvent);
+
+            const [helpHandler] = Array.from(elements.helpLink.listeners.click || []);
+            expect(typeof helpHandler).toBe('function');
+            const helpPreventDefault = jest.fn();
+            helpHandler({ preventDefault: helpPreventDefault, stopPropagation: jest.fn(), target: elements.helpLink });
+
+            expect(helpPreventDefault).toHaveBeenCalled();
+            expect(global.document.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({
+                type: 'auth:navigate',
+                detail: { action: 'help' },
+            }));
+            expect(elements.menu.classList.contains('hidden')).toBe(true);
+
+            buttonHandler(clickEvent);
+            global.document.dispatchEvent.mockClear();
+
+            const [settingsHandler] = Array.from(elements.settingsLink.listeners.click || []);
+            expect(typeof settingsHandler).toBe('function');
+            const settingsPreventDefault = jest.fn();
+            settingsHandler({ preventDefault: settingsPreventDefault, stopPropagation: jest.fn(), target: elements.settingsLink });
+
+            expect(settingsPreventDefault).toHaveBeenCalled();
+            expect(global.document.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({
+                type: 'auth:navigate',
+                detail: { action: 'settings' },
+            }));
         });
     });
 


### PR DESCRIPTION
## Summary
- update the auth helpers to drive the new user dropdown button, close logic and navigation events
- wire the logout, help and settings entries to the existing flows while keeping the menu accessible
- expand the auth unit tests with DOM stubs for the dropdown, exercising the new behaviour

## Testing
- npm test -- --runTestsByPath frontend/js/__tests__/auth.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb3a853b54832683ba526aca3358a4