### PR TITLE
Lock client detail inputs via disabled state

### DIFF
--- a/frontend/js/__tests__/forms.test.js
+++ b/frontend/js/__tests__/forms.test.js
@@ -180,6 +180,7 @@ describe('selección de clientes', () => {
 
         [direccionInput, telefonoInput, emailInput, cuitInput].forEach(input => {
             expect(input.readOnly).toBe(true);
+            expect(input.disabled).toBe(true);
             expect(input.classList.contains('client-detail-locked')).toBe(true);
             expect(input.classList.contains('client-detail-empty')).toBe(false);
         });
@@ -212,7 +213,9 @@ describe('selección de clientes', () => {
         expect(document.getElementById('cliente_cuit').value).toBe('');
         expect(document.getElementById('cliente_cuit').classList.contains('client-detail-empty')).toBe(true);
         expect(document.getElementById('cliente_cuit').readOnly).toBe(false);
+        expect(document.getElementById('cliente_cuit').disabled).toBe(false);
         expect(document.getElementById('direccion').readOnly).toBe(true);
+        expect(document.getElementById('direccion').disabled).toBe(true);
 
         select.selectedIndex = 2;
         expect(select.selectedIndex).toBe(2);
@@ -224,7 +227,9 @@ describe('selección de clientes', () => {
         expect(document.getElementById('cliente_cuit').value).toBe('');
         expect(document.getElementById('cliente_cuit').classList.contains('client-detail-empty')).toBe(true);
         expect(document.getElementById('cliente_cuit').readOnly).toBe(false);
+        expect(document.getElementById('cliente_cuit').disabled).toBe(false);
         expect(document.getElementById('direccion').readOnly).toBe(true);
+        expect(document.getElementById('direccion').disabled).toBe(true);
     });
 
     test('resetForm limpia la selección y los campos de cliente', () => {
@@ -248,6 +253,7 @@ describe('selección de clientes', () => {
         expect(document.getElementById('cliente_email').value).toBe('');
         expect(document.getElementById('cliente_cuit').value).toBe('');
         expect(document.getElementById('direccion').readOnly).toBe(false);
+        expect(document.getElementById('direccion').disabled).toBe(false);
         expect(document.getElementById('direccion').classList.contains('client-detail-empty')).toBe(true);
     });
 });

--- a/frontend/js/forms.js
+++ b/frontend/js/forms.js
@@ -157,11 +157,15 @@ function refreshClientDetailFieldState(element, { lockWhenFilled = false } = {})
 
     if (lockWhenFilled) {
         element.readOnly = hasValue;
+        element.disabled = hasValue;
     } else if (!hasValue) {
         element.readOnly = false;
+        element.disabled = false;
     }
 
-    if (element.readOnly && hasValue) {
+    const isLocked = hasValue && (element.disabled || element.readOnly);
+
+    if (isLocked) {
         element.classList.add(CLIENT_DETAIL_LOCKED_CLASS);
     } else {
         element.classList.remove(CLIENT_DETAIL_LOCKED_CLASS);


### PR DESCRIPTION
## Summary
- toggle the disabled state when client detail fields are auto-filled to keep the locked styling in sync
- extend client selection tests to verify disabled behaviour for both locked and cleared inputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb4e306dd48326b8e2496130b803ef