### PR TITLE
feat: add toggle control for component stage actions

### DIFF
--- a/frontend/css/styles.build.css
+++ b/frontend/css/styles.build.css
@@ -804,6 +804,80 @@ video {
   margin-top: 1.5rem;
 }
 
+.toggle-switch {
+  position: relative;
+  display: inline-flex;
+  height: 1.5rem;
+  width: 2.75rem;
+  flex-shrink: 0;
+  cursor: pointer;
+  align-items: center;
+}
+
+.toggle-switch-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.toggle-switch-slider {
+  position: relative;
+  display: inline-block;
+  height: 100%;
+  width: 100%;
+  border-radius: 9999px;
+  --tw-bg-opacity: 1;
+  background-color: rgb(209 213 219 / var(--tw-bg-opacity, 1));
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-duration: 200ms;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.toggle-switch-slider::after {
+  content: '';
+  position: absolute;
+  top: 0.125rem;
+  left: 0.125rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 9999px;
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgb(15 23 42 / 0.2);
+  transition: transform 0.2s ease-in-out;
+}
+
+.toggle-switch-input:checked + .toggle-switch-slider {
+  --tw-bg-opacity: 1;
+  background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+}
+
+.toggle-switch-input:checked + .toggle-switch-slider::after {
+  transform: translateX(1.25rem);
+}
+
+.toggle-switch-input:focus-visible + .toggle-switch-slider {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity, 1));
+  --tw-ring-offset-width: 2px;
+}
+
+.stage-action-status {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+}
+
 .fixed {
   position: fixed;
 }
@@ -964,6 +1038,10 @@ video {
 
 .gap-2 {
   gap: 0.5rem;
+}
+
+.gap-3 {
+  gap: 0.75rem;
 }
 
 .gap-4 {
@@ -1278,6 +1356,10 @@ video {
   --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.filter {
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
 .hover\:bg-blue-700:hover {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -74,4 +74,45 @@
     .form-card + .form-card {
         @apply mt-6;
     }
+
+    .toggle-switch {
+        @apply relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer items-center;
+    }
+
+    .toggle-switch-input {
+        @apply sr-only;
+    }
+
+    .toggle-switch-slider {
+        @apply relative inline-block h-full w-full rounded-full bg-gray-300 transition-colors duration-200 ease-in-out;
+    }
+
+    .toggle-switch-slider::after {
+        content: '';
+        position: absolute;
+        top: 0.125rem;
+        left: 0.125rem;
+        width: 1.25rem;
+        height: 1.25rem;
+        border-radius: 9999px;
+        background-color: #fff;
+        box-shadow: 0 2px 4px rgb(15 23 42 / 0.2);
+        transition: transform 0.2s ease-in-out;
+    }
+
+    .toggle-switch-input:checked + .toggle-switch-slider {
+        @apply bg-blue-600;
+    }
+
+    .toggle-switch-input:checked + .toggle-switch-slider::after {
+        transform: translateX(1.25rem);
+    }
+
+    .toggle-switch-input:focus-visible + .toggle-switch-slider {
+        @apply ring-2 ring-blue-400 ring-offset-2;
+    }
+
+    .stage-action-status {
+        @apply text-sm font-medium text-gray-600;
+    }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -213,7 +213,9 @@
                                 <div class="sm:col-span-2">
                                     <input type="text" class="w-full stage-details">
                                 </div>
-                                <div class="sm:col-span-2 flex space-x-4 stage-actions"></div>
+                                <div class="sm:col-span-2">
+                                    <div class="stage-actions flex items-center gap-3"></div>
+                                </div>
                             </div>
                         </template>
                         <!-- Sanitización -->


### PR DESCRIPTION
## Summary
- replace the component stage radio buttons with a single toggle switch that keeps the hidden action value in sync with the stage label
- update the stage template markup to host the toggle container and status text
- add toggle styling to the Tailwind component layer and rebuild the compiled stylesheet

## Testing
- npm run build:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb6325e67c8326a84f6456fe8ad3e8