### PR TITLE
Refactor auth flow to session storage

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -417,19 +417,19 @@
         <div class="bg-white rounded-lg shadow-xl w-full max-w-md">
             <div class="p-6 space-y-4">
                 <h2 class="text-2xl font-semibold text-gray-800">Iniciar sesión</h2>
-                <p class="text-sm text-gray-600">Ingresa tu usuario registrado y el token de acceso otorgado por el administrador.</p>
+                <p class="text-sm text-gray-600">Ingresa tu mail registrado y la contraseña correspondiente.</p>
                 <form id="login-form" class="space-y-4">
                     <div>
-                        <label for="login-usuario" class="block text-sm font-medium text-gray-700 mb-1">Usuario</label>
-                        <input id="login-usuario" name="usuario" type="text" autocomplete="username" class="w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+                        <label for="login-mail" class="block text-sm font-medium text-gray-700 mb-1">Mail</label>
+                        <input id="login-mail" name="mail" type="email" autocomplete="username" class="w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required>
                     </div>
                     <div>
-                        <label for="login-token" class="block text-sm font-medium text-gray-700 mb-1">Token</label>
-                        <input id="login-token" name="token" type="password" autocomplete="current-password" class="w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+                        <label for="login-password" class="block text-sm font-medium text-gray-700 mb-1">Contraseña</label>
+                        <input id="login-password" name="password" type="password" autocomplete="current-password" class="w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required>
                     </div>
                     <p id="login-error" class="text-sm text-red-600 hidden"></p>
                     <button type="submit" class="w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
-                        Ingresar
+                        Iniciar sesión
                     </button>
                 </form>
             </div>

--- a/frontend/js/__tests__/api.test.js
+++ b/frontend/js/__tests__/api.test.js
@@ -7,9 +7,6 @@ import fetchMock from 'fetch-mock';
 
 const API_URL = 'https://api.example.com/mantenimientos';
 const loadApiModule = () => import('../api.js');
-const AUTH_STORAGE_KEY = 'reportesOBM.auth';
-const defaultAuth = { token: 'test-token', usuario: 'Tester' };
-
 let originalApiUrl;
 
 describe('api.js', () => {
@@ -21,20 +18,6 @@ describe('api.js', () => {
         fetchMock.hardReset();
         jest.resetModules();
         process.env.API_URL = API_URL;
-        const storage = {};
-        global.localStorage = {
-            getItem: key => (Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null),
-            setItem: (key, value) => {
-                storage[key] = String(value);
-            },
-            removeItem: key => {
-                delete storage[key];
-            },
-            clear: () => {
-                Object.keys(storage).forEach(prop => delete storage[prop]);
-            },
-        };
-        localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(defaultAuth));
         fetchMock.config.Request = typeof Request === 'function' ? Request : fetchMock.config.Request;
         fetchMock.config.Response = typeof Response === 'function' ? Response : fetchMock.config.Response;
         fetchMock.config.Headers = typeof Headers === 'function' ? Headers : fetchMock.config.Headers;
@@ -46,7 +29,6 @@ describe('api.js', () => {
 
     afterEach(() => {
         fetchMock.hardReset();
-        delete global.localStorage;
     });
 
     afterAll(() => {
@@ -76,8 +58,6 @@ describe('api.js', () => {
         expect(JSON.parse(lastCall.options.body)).toEqual({
             action: 'guardar',
             ...payload,
-            token: defaultAuth.token,
-            usuario: defaultAuth.usuario,
         });
     });
 
@@ -97,8 +77,6 @@ describe('api.js', () => {
         expect(JSON.parse(lastCall.options.body)).toEqual({
             action: 'buscar',
             ...filtros,
-            token: defaultAuth.token,
-            usuario: defaultAuth.usuario,
         });
     });
 
@@ -124,8 +102,6 @@ describe('api.js', () => {
         expect(lastCall.options.method).toBe('post');
         expect(JSON.parse(lastCall.options.body)).toEqual({
             action: 'dashboard',
-            token: defaultAuth.token,
-            usuario: defaultAuth.usuario,
         });
     });
 

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -1,16 +1,9 @@
 import { API_URL } from './config.js';
-import { getAuthPayload } from './auth.js';
 import { state } from './state.js';
 
-async function postJSON(payload, { requireAuth = true } = {}) {
+async function postJSON(payload) {
     if (!API_URL) {
         throw new Error('API_URL no está configurada.');
-    }
-
-    const requestPayload = { ...payload };
-
-    if (requireAuth) {
-        Object.assign(requestPayload, getAuthPayload());
     }
 
     let response;
@@ -20,7 +13,7 @@ async function postJSON(payload, { requireAuth = true } = {}) {
             headers: {
                 'Content-Type': 'text/plain; charset=utf-8',
             },
-            body: JSON.stringify(requestPayload),
+            body: JSON.stringify(payload),
         });
     } catch (error) {
         if (error?.name === 'AbortError') {


### PR DESCRIPTION
## Summary
- store session data in sessionStorage as Nombre/Cargo/Rol and update the login modal to accept mail/contraseña
- refactor auth helpers to resolve session visibility, expose user accessors, and drop token usage from the API client
- update unit tests to cover the new session flow and credential payloads

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc87c3b8b88326ae9ba71a3c75a6c1