### PR TITLE
feat: redesign auth header and login view

### DIFF
--- a/frontend/css/styles.build.css
+++ b/frontend/css/styles.build.css
@@ -698,22 +698,49 @@ video {
   color: rgb(156 163 175 / var(--tw-text-opacity, 1));
 }
 
-.user-menu {
-  position: relative;
-  display: inline-flex;
+.session-info {
+  display: flex;
   align-items: center;
   justify-content: flex-end;
+  gap: 1rem;
+  text-align: right;
 }
 
-.user-menu__trigger {
+.session-info__details {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.session-info__name {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 600;
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
+}
+
+.session-info__role {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+.session-info__logout-button {
   display: inline-flex;
-  height: 3rem;
-  width: 3rem;
   align-items: center;
   justify-content: center;
-  border-radius: 9999px;
+  border-radius: 0.5rem;
   --tw-bg-opacity: 1;
-  background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+  background-color: rgb(239 68 68 / var(--tw-bg-opacity, 1));
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
   font-weight: 600;
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
@@ -726,7 +753,138 @@ video {
   transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 }
 
-.user-menu__trigger:focus-visible {
+.session-info__logout-button:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(248 113 113 / var(--tw-ring-opacity, 1));
+  --tw-ring-offset-width: 2px;
+}
+
+.session-info__logout-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.session-info__logout-button:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(220 38 38 / var(--tw-bg-opacity, 1));
+}
+
+.session-info__logout-button:focus-visible {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(252 165 165 / var(--tw-ring-opacity, 1));
+}
+
+.app-container {
+  min-height: 100vh;
+}
+
+.login-container {
+  display: flex;
+  min-height: 100vh;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  --tw-bg-opacity: 1;
+  background-color: rgb(15 23 42 / var(--tw-bg-opacity, 1));
+  padding: 1.5rem;
+  background-image: radial-gradient(circle at top, rgba(59, 130, 246, 0.35), transparent 55%);
+}
+
+.login-card {
+  width: 100%;
+  max-width: 28rem;
+  border-radius: 1rem;
+  border-width: 1px;
+  border-color: rgb(255 255 255 / 0.1);
+  background-color: rgb(255 255 255 / 0.95);
+  padding: 2rem;
+  --tw-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+  --tw-shadow-colored: 0 25px 50px -12px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  --tw-backdrop-blur: blur(8px);
+  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+
+.login-card__header {
+  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
+}
+
+.login-card__logo {
+  height: 4rem;
+  width: auto;
+}
+
+.login-card__title {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 600;
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
+}
+
+.login-card__subtitle {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.login-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.login-form__label {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+}
+
+.login-form__input {
+  width: 100%;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  transition-property: box-shadow;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+}
+
+.login-form__input:focus {
+  --tw-border-opacity: 1;
+  border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
   outline: 2px solid transparent;
   outline-offset: 2px;
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
@@ -734,127 +892,46 @@ video {
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity, 1));
-  --tw-ring-offset-width: 2px;
 }
 
-.user-menu__trigger:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-.user-menu__trigger:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(29 78 216 / var(--tw-bg-opacity, 1));
-}
-
-.user-menu__initials {
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-}
-
-.user-menu__dropdown {
-  pointer-events: none;
-  position: absolute;
-  right: 0px;
-  top: 100%;
-  z-index: 30;
-  margin-top: 0.75rem;
-  width: 15rem;
-  transform-origin: top right;
-  --tw-translate-y: -0.5rem;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-  border-radius: 1rem;
-  border-width: 1px;
-  --tw-border-opacity: 1;
-  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
-  padding: 1rem;
-  opacity: 0;
-  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  transition-property: all;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-}
-
-.user-menu--open .user-menu__dropdown {
-  pointer-events: auto;
-  --tw-translate-y: 0px;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-  opacity: 1;
-}
-
-.user-menu__header {
-  margin-bottom: 0.75rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
-}
-
-.user-menu__welcome {
-  font-size: 0.75rem;
-  line-height: 1rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.025em;
-  --tw-text-opacity: 1;
-  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
-}
-
-.user-menu__name {
-  font-size: 1rem;
-  line-height: 1.5rem;
-  font-weight: 600;
-  --tw-text-opacity: 1;
-  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
-}
-
-.user-menu__separator {
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
-  height: 1px;
-  --tw-bg-opacity: 1;
-  background-color: rgb(229 231 235 / var(--tw-bg-opacity, 1));
-}
-
-.user-menu__item {
-  display: block;
-  width: 100%;
-  cursor: pointer;
-  border-radius: 0.75rem;
-  border-width: 1px;
-  border-color: transparent;
-  background-color: transparent;
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  text-align: left;
+.login-error {
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
   --tw-text-opacity: 1;
-  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
-  text-decoration-line: none;
+  color: rgb(220 38 38 / var(--tw-text-opacity, 1));
+}
+
+.login-submit-button {
+  margin-top: 0.5rem;
+  display: inline-flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+  --tw-bg-opacity: 1;
+  background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 600;
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
   transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 }
 
-.user-menu__item:hover {
+.login-submit-button:hover {
   --tw-bg-opacity: 1;
-  background-color: rgb(239 246 255 / var(--tw-bg-opacity, 1));
-  --tw-text-opacity: 1;
-  color: rgb(29 78 216 / var(--tw-text-opacity, 1));
+  background-color: rgb(29 78 216 / var(--tw-bg-opacity, 1));
 }
 
-.user-menu__item:focus-visible {
+.login-submit-button:focus-visible {
   outline: 2px solid transparent;
   outline-offset: 2px;
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
@@ -863,23 +940,6 @@ video {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity, 1));
   --tw-ring-offset-width: 2px;
-}
-
-.user-menu__logout {
-  --tw-text-opacity: 1;
-  color: rgb(220 38 38 / var(--tw-text-opacity, 1));
-}
-
-.user-menu__logout:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 242 242 / var(--tw-bg-opacity, 1));
-  --tw-text-opacity: 1;
-  color: rgb(185 28 28 / var(--tw-text-opacity, 1));
-}
-
-.user-menu__logout:focus-visible {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(248 113 113 / var(--tw-ring-opacity, 1));
 }
 
 .tab-button {
@@ -1288,18 +1348,6 @@ video {
   color: rgb(51 65 85 / var(--tw-text-opacity, 1));
 }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
 .fixed {
   position: fixed;
 }
@@ -1310,10 +1358,6 @@ video {
 
 .z-40 {
   z-index: 40;
-}
-
-.z-50 {
-  z-index: 50;
 }
 
 .mx-auto {
@@ -1382,6 +1426,10 @@ video {
   max-height: 100vh;
 }
 
+.min-h-screen {
+  min-height: 100vh;
+}
+
 .w-full {
   width: 100%;
 }
@@ -1396,10 +1444,6 @@ video {
 
 .max-w-7xl {
   max-width: 80rem;
-}
-
-.max-w-md {
-  max-width: 28rem;
 }
 
 .grid-cols-1 {
@@ -1480,12 +1524,6 @@ video {
   --tw-space-x-reverse: 0;
   margin-right: calc(1rem * var(--tw-space-x-reverse));
   margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
-}
-
-.space-y-4 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-y-reverse: 0;
-  margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(1rem * var(--tw-space-y-reverse));
 }
 
 .space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -1576,11 +1614,6 @@ video {
   background-color: rgb(75 85 99 / var(--tw-bg-opacity, 1));
 }
 
-.bg-gray-900 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(17 24 39 / var(--tw-bg-opacity, 1));
-}
-
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
@@ -1588,10 +1621,6 @@ video {
 
 .bg-opacity-50 {
   --tw-bg-opacity: 0.5;
-}
-
-.bg-opacity-60 {
-  --tw-bg-opacity: 0.6;
 }
 
 .p-2 {
@@ -1644,11 +1673,6 @@ video {
   text-align: center;
 }
 
-.text-2xl {
-  font-size: 1.5rem;
-  line-height: 2rem;
-}
-
 .text-3xl {
   font-size: 1.875rem;
   line-height: 2.25rem;
@@ -1698,11 +1722,6 @@ video {
 .text-gray-500 {
   --tw-text-opacity: 1;
   color: rgb(107 114 128 / var(--tw-text-opacity, 1));
-}
-
-.text-gray-600 {
-  --tw-text-opacity: 1;
-  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
 }
 
 .text-gray-700 {
@@ -1781,35 +1800,15 @@ video {
   border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
 }
 
-.focus\:outline-none:focus {
-  outline: 2px solid transparent;
-  outline-offset: 2px;
-}
-
 .focus\:ring:focus {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
 
-.focus\:ring-2:focus {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-}
-
 .focus\:ring-blue-200:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(191 219 254 / var(--tw-ring-opacity, 1));
-}
-
-.focus\:ring-blue-500:focus {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(59 130 246 / var(--tw-ring-opacity, 1));
-}
-
-.focus\:ring-offset-2:focus {
-  --tw-ring-offset-width: 2px;
 }
 
 @media (min-width: 640px) {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -39,68 +39,85 @@
         @apply text-xs font-semibold text-gray-400;
     }
 
-    .user-menu {
-        @apply relative inline-flex items-center justify-end;
+    .session-info {
+        @apply flex items-center justify-end gap-4 text-right;
     }
 
-    .user-menu__trigger {
-        @apply inline-flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 font-semibold text-white shadow-md transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60;
+    .session-info__details {
+        @apply flex flex-col items-end;
     }
 
-    .user-menu__trigger:hover {
-        @apply bg-blue-700;
-    }
-
-    .user-menu__initials {
-        @apply text-lg font-semibold uppercase;
-    }
-
-    .user-menu__dropdown {
-        @apply pointer-events-none absolute right-0 top-full z-30 mt-3 w-60 origin-top-right -translate-y-2 transform rounded-2xl border border-gray-200 bg-white p-4 shadow-xl opacity-0 transition-all duration-150 ease-out;
-    }
-
-    .user-menu--open .user-menu__dropdown {
-        @apply pointer-events-auto translate-y-0 opacity-100;
-    }
-
-    .user-menu__header {
-        @apply mb-3 flex flex-col gap-0.5;
-    }
-
-    .user-menu__welcome {
-        @apply text-xs font-medium uppercase tracking-wide text-gray-400;
-    }
-
-    .user-menu__name {
+    .session-info__name {
         @apply text-base font-semibold text-gray-800;
     }
 
-    .user-menu__separator {
-        @apply my-2 h-px bg-gray-200;
+    .session-info__role {
+        @apply text-sm font-medium text-gray-500;
     }
 
-    .user-menu__item {
-        @apply block w-full cursor-pointer rounded-xl border border-transparent bg-transparent px-3 py-2 text-left text-sm font-medium text-gray-700 no-underline transition-colors duration-150 ease-out;
+    .session-info__logout-button {
+        @apply inline-flex items-center justify-center rounded-lg bg-red-500 px-4 py-2 text-sm font-semibold text-white shadow-md transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60;
     }
 
-    .user-menu__item:hover {
-        @apply bg-blue-50 text-blue-700;
+    .session-info__logout-button:hover {
+        @apply bg-red-600;
     }
 
-    .user-menu__item:focus-visible {
-        @apply outline-none ring-2 ring-blue-400 ring-offset-2;
+    .session-info__logout-button:focus-visible {
+        @apply ring-red-300;
     }
 
-    .user-menu__logout {
-        @apply text-red-600;
+    .app-container {
+        @apply min-h-screen;
     }
 
-    .user-menu__logout:hover {
-        @apply bg-red-50 text-red-700;
+    .login-container {
+        @apply flex min-h-screen w-full items-center justify-center bg-slate-900 p-6;
+        background-image: radial-gradient(circle at top, rgba(59, 130, 246, 0.35), transparent 55%);
     }
 
-    .user-menu__logout:focus-visible {
-        @apply ring-red-400;
+    .login-card {
+        @apply w-full max-w-md rounded-2xl border border-white/10 bg-white/95 p-8 shadow-2xl backdrop-blur;
+    }
+
+    .login-card__header {
+        @apply mb-8 flex flex-col items-center gap-4 text-center;
+    }
+
+    .login-card__logo {
+        @apply h-16 w-auto;
+    }
+
+    .login-card__title {
+        @apply text-2xl font-semibold text-gray-800;
+    }
+
+    .login-card__subtitle {
+        @apply text-sm text-gray-500;
+    }
+
+    .login-form {
+        @apply flex flex-col gap-4;
+    }
+
+    .login-form__field {
+        @apply flex flex-col gap-1;
+    }
+
+    .login-form__label {
+        @apply text-sm font-medium text-gray-700;
+    }
+
+    .login-form__input {
+        @apply w-full rounded-lg border border-gray-300 px-3 py-2 text-base text-gray-700 shadow-sm transition-shadow duration-150 ease-out focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400;
+    }
+
+    .login-error {
+        @apply text-sm font-medium text-red-600;
+    }
+
+    .login-submit-button {
+        @apply mt-2 inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors duration-150 ease-out hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2;
     }
 
     .tab-button {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,38 +8,30 @@
     <link rel="stylesheet" href="./css/styles.build.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0"></script>
 </head>
-<body class="bg-gray-100">
-    <div class="container mx-auto p-4 md:p-8 max-w-7xl">
-        <header class="app-header no-print">
-            <div class="app-header__column app-header__column--logo">
-                <img src="/OHM-agua.png" alt="Logo OHM Agua" class="app-header__logo-image">
-            </div>
-            <div class="app-header__column app-header__column--titles">
-                <h1 class="app-header__title">Sistema de Gestión de Mantenimientos RO</h1>
-                <p class="app-header__subtitle">ID del Protocolo: PMA-RO-RES-12</p>
-                <span id="app-version" class="app-header__version"></span>
-            </div>
-            <div class="app-header__column app-header__column--actions">
-                <div id="auth-user-panel" class="user-menu hidden">
-                    <button id="user-menu-button" type="button" class="user-menu__trigger" aria-haspopup="true" aria-expanded="false" disabled>
-                        <span id="user-menu-initials" class="user-menu__initials" aria-hidden="true"></span>
-                        <span class="sr-only">Abrir menú de usuario</span>
-                    </button>
-                    <div id="user-menu-dropdown" class="user-menu__dropdown" role="menu" aria-labelledby="user-menu-button">
-                        <div class="user-menu__header">
-                            <span class="user-menu__welcome">Sesión activa</span>
-                            <span id="current-user" class="user-menu__name"></span>
+<body class="bg-gray-100 min-h-screen">
+    <div class="app-container hidden">
+        <div class="container mx-auto p-4 md:p-8 max-w-7xl">
+            <header class="app-header no-print">
+                <div class="app-header__column app-header__column--logo">
+                    <img src="/OHM-agua.png" alt="Logo OHM Agua" class="app-header__logo-image">
+                </div>
+                <div class="app-header__column app-header__column--titles">
+                    <h1 class="app-header__title">Sistema de Gestión de Mantenimientos RO</h1>
+                    <p class="app-header__subtitle">ID del Protocolo: PMA-RO-RES-12</p>
+                    <span id="app-version" class="app-header__version"></span>
+                </div>
+                <div class="app-header__column app-header__column--actions">
+                    <div id="auth-user-panel" class="session-info hidden" aria-live="polite">
+                        <div class="session-info__details">
+                            <span id="current-user" class="session-info__name"></span>
+                            <span id="current-user-role" class="session-info__role"></span>
                         </div>
-                        <div class="user-menu__separator" role="none"></div>
-                        <a href="#" class="user-menu__item" role="menuitem">Ayuda</a>
-                        <a href="#" class="user-menu__item" role="menuitem">Configuración</a>
-                        <button id="logout-button" type="button" class="user-menu__item user-menu__logout" role="menuitem" disabled>
+                        <button id="logout-button" type="button" class="session-info__logout-button" disabled>
                             Cerrar sesión
                         </button>
-                    </div>
-                </div>
-            </div>
-        </header>
+        </div>
+        </div>
+            </header>
 
         <div class="print-header">
             <div class="print-header-text">
@@ -411,28 +403,30 @@
                 </div>
             </div>
         </div>
+        </div>
     </div>
 
-    <div id="login-modal" class="fixed inset-0 bg-gray-900 bg-opacity-60 hidden flex items-center justify-center p-4 z-50">
-        <div class="bg-white rounded-lg shadow-xl w-full max-w-md">
-            <div class="p-6 space-y-4">
-                <h2 class="text-2xl font-semibold text-gray-800">Iniciar sesión</h2>
-                <p class="text-sm text-gray-600">Ingresa tu mail registrado y la contraseña correspondiente.</p>
-                <form id="login-form" class="space-y-4">
-                    <div>
-                        <label for="login-mail" class="block text-sm font-medium text-gray-700 mb-1">Mail</label>
-                        <input id="login-mail" name="mail" type="email" autocomplete="username" class="w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required>
-                    </div>
-                    <div>
-                        <label for="login-password" class="block text-sm font-medium text-gray-700 mb-1">Contraseña</label>
-                        <input id="login-password" name="password" type="password" autocomplete="current-password" class="w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required>
-                    </div>
-                    <p id="login-error" class="text-sm text-red-600 hidden"></p>
-                    <button type="submit" class="w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
-                        Iniciar sesión
-                    </button>
-                </form>
+    <div id="login-container" class="login-container">
+        <div class="login-card" role="dialog" aria-labelledby="login-title" aria-modal="true">
+            <div class="login-card__header">
+                <img src="/OHM-agua.png" alt="Logo OHM Agua" class="login-card__logo">
+                <h2 id="login-title" class="login-card__title">Iniciar sesión</h2>
+                <p class="login-card__subtitle">Ingresa tu mail registrado y la contraseña correspondiente.</p>
             </div>
+            <form id="login-form" class="login-form">
+                <div class="login-form__field">
+                    <label for="login-mail" class="login-form__label">Mail</label>
+                    <input id="login-mail" name="mail" type="email" autocomplete="username" class="login-form__input" required>
+                </div>
+                <div class="login-form__field">
+                    <label for="login-password" class="login-form__label">Contraseña</label>
+                    <input id="login-password" name="password" type="password" autocomplete="current-password" class="login-form__input" required>
+                </div>
+                <p id="login-error" class="login-error hidden" role="alert"></p>
+                <button type="submit" class="login-submit-button">
+                    Iniciar sesión
+                </button>
+            </form>
         </div>
     </div>
 

--- a/frontend/js/__tests__/auth.test.js
+++ b/frontend/js/__tests__/auth.test.js
@@ -54,43 +54,56 @@ const createClassList = initial => {
 const setupDocumentMock = () => {
     const panel = {
         classList: createClassList(['hidden']),
-        contains: jest.fn(() => false),
     };
     const userLabel = { textContent: '' };
+    const userRole = { textContent: '' };
     const logoutButton = { disabled: true, addEventListener: jest.fn() };
-    const userMenuButton = {
-        disabled: true,
-        attributes: { 'aria-expanded': 'false' },
-        setAttribute: jest.fn((name, value) => {
-            userMenuButton.attributes[name] = value;
-        }),
-        getAttribute: jest.fn(name => userMenuButton.attributes[name]),
-        addEventListener: jest.fn(),
-    };
-    const userMenuInitials = { textContent: '' };
     const mainView = { classList: createClassList([]) };
+    const loginContainer = { classList: createClassList([]) };
+    const form = {
+        addEventListener: jest.fn(),
+        querySelectorAll: jest.fn(() => []),
+        reset: jest.fn(),
+    };
+    const error = {
+        textContent: '',
+        classList: createClassList(['hidden']),
+    };
+    const mailInput = { value: '', focus: jest.fn() };
+    const passwordInput = { value: '' };
 
     const elements = {
         panel,
         userLabel,
+        userRole,
         logoutButton,
-        userMenuButton,
-        userMenuInitials,
         mainView,
+        loginContainer,
     };
 
     const map = {
         'auth-user-panel': panel,
         'current-user': userLabel,
+        'current-user-role': userRole,
         'logout-button': logoutButton,
-        'user-menu-button': userMenuButton,
-        'user-menu-initials': userMenuInitials,
+        'login-form': form,
+        'login-error': error,
+        'login-mail': mailInput,
+        'login-password': passwordInput,
+        'login-container': loginContainer,
     };
 
     global.document = {
-        getElementById: jest.fn(id => map[id] || null),
-        querySelector: jest.fn(selector => (selector === '.container' ? mainView : null)),
-        addEventListener: jest.fn(),
+        getElementById: jest.fn(id => (Object.prototype.hasOwnProperty.call(map, id) ? map[id] : null)),
+        querySelector: jest.fn(selector => {
+            if (selector === '.app-container') {
+                return mainView;
+            }
+            if (selector === '.login-container') {
+                return loginContainer;
+            }
+            return null;
+        }),
     };
 
     return elements;
@@ -137,10 +150,7 @@ describe('auth helpers', () => {
             expect(loadStoredAuth()).toEqual({ nombre: 'Ana', cargo: 'Analista', rol: 'Administradora' });
             expect(elements.panel.classList.contains('hidden')).toBe(false);
             expect(elements.userLabel.textContent).toBe('Ana');
-            expect(elements.userMenuInitials.textContent).toBe('A');
-            expect(elements.userMenuButton.disabled).toBe(false);
-            expect(elements.userMenuButton.attributes['aria-expanded']).toBe('false');
-            expect(elements.userMenuButton.attributes['aria-label']).toBe('Abrir menú de Ana');
+            expect(elements.userRole.textContent).toBe('Administradora');
             expect(elements.logoutButton.disabled).toBe(false);
         });
 
@@ -154,7 +164,7 @@ describe('auth helpers', () => {
             expect(storage.setItem).not.toHaveBeenCalled();
             expect(loadStoredAuth()).toEqual(auth);
             expect(elements.panel.classList.contains('hidden')).toBe(false);
-            expect(elements.userMenuInitials.textContent).toBe('L');
+            expect(elements.userRole.textContent).toBe('Usuario');
         });
     });
 
@@ -173,9 +183,7 @@ describe('auth helpers', () => {
             expect(loadStoredAuth()).toBeNull();
             expect(elements.panel.classList.contains('hidden')).toBe(true);
             expect(elements.userLabel.textContent).toBe('');
-            expect(elements.userMenuInitials.textContent).toBe('');
-            expect(elements.userMenuButton.disabled).toBe(true);
-            expect(elements.userMenuButton.attributes['aria-label']).toBe('Abrir menú de usuario');
+            expect(elements.userRole.textContent).toBe('');
             expect(elements.logoutButton.disabled).toBe(true);
         });
 
@@ -187,18 +195,14 @@ describe('auth helpers', () => {
             elements.panel.classList.remove('hidden');
             elements.logoutButton.disabled = false;
             elements.userLabel.textContent = 'Demo';
-            elements.userMenuInitials.textContent = 'D';
-            elements.userMenuButton.disabled = false;
-            elements.userMenuButton.attributes['aria-label'] = 'Abrir menú de Demo';
+            elements.userRole.textContent = 'Demo Rol';
 
             expect(() => clearStoredAuth()).not.toThrow();
             expect(storage.removeItem).not.toHaveBeenCalled();
             expect(elements.panel.classList.contains('hidden')).toBe(true);
             expect(elements.logoutButton.disabled).toBe(true);
             expect(elements.userLabel.textContent).toBe('');
-            expect(elements.userMenuInitials.textContent).toBe('');
-            expect(elements.userMenuButton.disabled).toBe(true);
-            expect(elements.userMenuButton.attributes['aria-label']).toBe('Abrir menú de usuario');
+            expect(elements.userRole.textContent).toBe('');
         });
     });
 

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -6,93 +6,6 @@ let cachedUser = null;
 let listenersBound = false;
 let pendingAuth = null;
 
-function getUserInitials(name) {
-    if (typeof name !== 'string') {
-        return '';
-    }
-
-    const parts = name
-        .trim()
-        .split(/\s+/)
-        .filter(Boolean);
-
-    if (parts.length === 0) {
-        return '';
-    }
-
-    const initials = parts
-        .slice(0, 2)
-        .map(part => part.charAt(0).toUpperCase())
-        .join('');
-
-    return initials;
-}
-
-function setUserMenuOpen(isOpen) {
-    const { panel, userMenuButton } = getElements();
-    if (!panel || !userMenuButton) {
-        return;
-    }
-
-    if (isOpen) {
-        panel.classList.add('user-menu--open');
-        userMenuButton.setAttribute('aria-expanded', 'true');
-    } else {
-        panel.classList.remove('user-menu--open');
-        userMenuButton.setAttribute('aria-expanded', 'false');
-    }
-}
-
-function toggleUserMenu() {
-    const { panel } = getElements();
-    if (!panel || panel.classList.contains('hidden')) {
-        return;
-    }
-
-    const isOpen = panel.classList.contains('user-menu--open');
-    setUserMenuOpen(!isOpen);
-}
-
-function handleUserMenuButtonClick(event) {
-    if (event) {
-        event.preventDefault();
-        event.stopPropagation();
-    }
-
-    const { userMenuButton } = getElements();
-    if (!userMenuButton || userMenuButton.disabled) {
-        return;
-    }
-
-    toggleUserMenu();
-}
-
-function handleDocumentClick(event) {
-    const { panel } = getElements();
-    if (!panel || panel.classList.contains('hidden') || !panel.classList.contains('user-menu--open')) {
-        return;
-    }
-
-    if (typeof panel.contains === 'function' && panel.contains(event.target)) {
-        return;
-    }
-
-    setUserMenuOpen(false);
-}
-
-function handleDocumentKeydown(event) {
-    if (event?.key !== 'Escape') {
-        return;
-    }
-
-    const { panel } = getElements();
-    if (!panel || panel.classList.contains('hidden') || !panel.classList.contains('user-menu--open')) {
-        return;
-    }
-
-    setUserMenuOpen(false);
-}
-
 function getStorage() {
     if (typeof window !== 'undefined') {
         if (window.sessionStorage) {
@@ -206,7 +119,7 @@ function getElements() {
     }
 
     return {
-        modal: document.getElementById('login-modal'),
+        loginContainer: document.getElementById('login-container'),
         form: document.getElementById('login-form'),
         error: document.getElementById('login-error'),
         mailInput: document.getElementById('login-mail'),
@@ -214,16 +127,15 @@ function getElements() {
         logoutButton: document.getElementById('logout-button'),
         panel: document.getElementById('auth-user-panel'),
         userLabel: document.getElementById('current-user'),
-        userMenuButton: document.getElementById('user-menu-button'),
-        userMenuInitials: document.getElementById('user-menu-initials'),
-        mainView: document.querySelector('.container'),
+        userRole: document.getElementById('current-user-role'),
+        mainView: document.querySelector('.app-container'),
     };
 }
 
 function showLoginModal() {
-    const { modal, error, mailInput } = getElements();
-    if (modal) {
-        modal.classList.remove('hidden');
+    const { loginContainer, error, mailInput } = getElements();
+    if (loginContainer) {
+        loginContainer.classList.remove('hidden');
     }
     if (error) {
         error.textContent = '';
@@ -235,9 +147,9 @@ function showLoginModal() {
 }
 
 function hideLoginModal() {
-    const { modal, form, error } = getElements();
-    if (modal) {
-        modal.classList.add('hidden');
+    const { loginContainer, form, error } = getElements();
+    if (loginContainer) {
+        loginContainer.classList.add('hidden');
     }
     if (form) {
         form.reset();
@@ -249,15 +161,21 @@ function hideLoginModal() {
 }
 
 function setMainViewVisible(isVisible) {
-    const { mainView } = getElements();
-    if (!mainView) {
-        return;
+    const { mainView, loginContainer } = getElements();
+    if (mainView) {
+        if (isVisible) {
+            mainView.classList.remove('hidden');
+        } else {
+            mainView.classList.add('hidden');
+        }
     }
 
-    if (isVisible) {
-        mainView.classList.remove('hidden');
-    } else {
-        mainView.classList.add('hidden');
+    if (loginContainer) {
+        if (isVisible) {
+            loginContainer.classList.add('hidden');
+        } else {
+            loginContainer.classList.remove('hidden');
+        }
     }
 }
 
@@ -294,29 +212,28 @@ function displayError(message) {
 }
 
 function updateUserPanel(auth) {
-    const { panel, userLabel, logoutButton, userMenuButton, userMenuInitials } = getElements();
-    if (!panel || !userLabel || !logoutButton || !userMenuButton || !userMenuInitials) {
+    const { panel, userLabel, userRole, logoutButton } = getElements();
+    if (!panel || !userLabel || !logoutButton) {
         return;
     }
 
-    setUserMenuOpen(false);
-
     const nombre = typeof auth?.nombre === 'string' ? auth.nombre.trim() : '';
+    const rol = typeof auth?.rol === 'string' ? auth.rol.trim() : '';
+    const cargo = typeof auth?.cargo === 'string' ? auth.cargo.trim() : '';
+    const roleLabel = rol || cargo;
 
     if (nombre) {
-        const initials = getUserInitials(nombre) || nombre.charAt(0).toUpperCase();
-
         userLabel.textContent = nombre;
-        userMenuInitials.textContent = initials;
-        userMenuButton.disabled = false;
-        userMenuButton.setAttribute('aria-label', `Abrir menú de ${nombre}`);
+        if (userRole) {
+            userRole.textContent = roleLabel || '';
+        }
         panel.classList.remove('hidden');
         logoutButton.disabled = false;
     } else {
         userLabel.textContent = '';
-        userMenuInitials.textContent = '';
-        userMenuButton.disabled = true;
-        userMenuButton.setAttribute('aria-label', 'Abrir menú de usuario');
+        if (userRole) {
+            userRole.textContent = '';
+        }
         panel.classList.add('hidden');
         logoutButton.disabled = true;
     }
@@ -440,7 +357,6 @@ function handleLogout(event) {
     if (event) {
         event.preventDefault();
     }
-    setUserMenuOpen(false);
     clearStoredAuth();
     setMainViewVisible(false);
     showLoginModal();
@@ -452,19 +368,12 @@ function bindEventListeners() {
         return;
     }
 
-    const { form, logoutButton, userMenuButton } = getElements();
+    const { form, logoutButton } = getElements();
     if (form) {
         form.addEventListener('submit', handleLoginSubmit);
     }
     if (logoutButton) {
         logoutButton.addEventListener('click', handleLogout);
-    }
-    if (userMenuButton) {
-        userMenuButton.addEventListener('click', handleUserMenuButtonClick);
-    }
-    if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
-        document.addEventListener('click', handleDocumentClick);
-        document.addEventListener('keydown', handleDocumentKeydown);
     }
 
     listenersBound = true;


### PR DESCRIPTION
## Summary
- restructure the header to show the signed-in user’s name and role with a dedicated logout button while wrapping the application in a new `.app-container`
- replace the modal-based authentication flow with a full-screen login container and update `auth.js` to toggle the app/login views
- refresh the shared styles and auth unit tests to cover the new layout and behaviour

## Testing
- npm run build:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc8f6e55fc8326ab5a5036ba583465