### PR TITLE
Add version action to Apps Script router

### DIFF
--- a/scripts/Codigo.txt
+++ b/scripts/Codigo.txt
@@ -477,6 +477,14 @@ function doPost(e) {
     const { action } = data;
 
     switch (action) {
+      case 'version': {
+        return ResponseFactory.success({
+          code: 'SistemaMantenimientosRO',
+          auth: true,
+          session: true
+        });
+      }
+
       /* --------- AUTENTICACIÓN / SESIONES --------- */
       case 'login': {
         const usuario = AuthService.authenticate(data.mail, data.password);


### PR DESCRIPTION
## Summary
- add a `version` action to the Apps Script router so the login tester can retrieve metadata without authentication

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf7ce8d15c832696942afef1c3e532