### PR TITLE
Gestionar token y expiración de sesión en API

### DIFF
--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -466,6 +466,12 @@ export function getCurrentUserRole() {
     return session?.user?.rol || '';
 }
 
+export function getCurrentToken() {
+    const session = loadStoredAuth();
+    const token = typeof session?.token === 'string' ? session.token.trim() : '';
+    return token || null;
+}
+
 export async function initializeAuth() {
     bindEventListeners();
 
@@ -484,6 +490,11 @@ export async function initializeAuth() {
 
 export function logout() {
     handleLogout();
+}
+
+export function handleSessionExpiration() {
+    handleLogout();
+    displayError('Tu sesión ha expirado. Por favor, ingresá de nuevo.');
 }
 
 export async function requireAuthentication() {


### PR DESCRIPTION
## Summary
- expone nuevas utilidades de autenticación para recuperar el token vigente y mostrar el mensaje de sesión expirada
- ajusta postJSON para adjuntar automáticamente el token, abortar cuando falta y disparar el manejo de expiración ante errores de token
- amplía las pruebas de auth y api para cubrir la inserción del token y el flujo completo de caducidad

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0273ff0008326b07e624afb20f008