### PR TITLE
test: mock main view and login elements

### DIFF
--- a/frontend/js/__tests__/auth.test.js
+++ b/frontend/js/__tests__/auth.test.js
@@ -237,6 +237,15 @@ const setupDocumentMock = () => {
     panel.appendChild(menuButton);
     panel.appendChild(menu);
 
+    const mainView = createElementStub({ initialClasses: ['hidden'] });
+    mainView.id = 'main-view';
+
+    const loginContainer = createElementStub({ initialClasses: ['hidden'] });
+    loginContainer.id = 'login-container';
+
+    const error = createElementStub({ initialClasses: ['hidden'] });
+    error.id = 'login-error';
+
     const docListeners = {};
 
     const elements = {
@@ -258,11 +267,12 @@ const setupDocumentMock = () => {
         'user-menu-toggle': menuButton,
         'user-menu': menu,
         'logout-button': logoutButton,
-        'login-modal': null,
+        'main-view': mainView,
+        'login-container': loginContainer,
         'login-form': null,
-        'login-error': null,
-        'login-usuario': null,
-        'login-token': null,
+        'login-error': error,
+        'login-mail': null,
+        'login-password': null,
     };
 
     global.document = {


### PR DESCRIPTION
## Summary
- add mock main view, login container, and error elements to the auth test document stub
- expose the new mocks through the getElementById map so auth helpers can access them

## Testing
- npm test -- auth *(fails: auth helper expectations were already failing prior to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d12f6a905c8326bba9924c404eab2f