### PR TITLE
Fix resetForm status color update

### DIFF
--- a/frontend/js/forms.js
+++ b/frontend/js/forms.js
@@ -772,10 +772,9 @@ export function resetForm() {
     clearDerivedFields();
     clearConversionOutputs();
 
-    applyStatusColors();
+    applyStatusColorsToSelects();
     resizeAutoResizeInputs();
 
-    applyStatusColorsToSelects();
     configureSanitizacionRadios();
 
 }


### PR DESCRIPTION
## Summary
- replace the outdated resetForm status color helper with applyStatusColorsToSelects
- remove the redundant second status color call after reset

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d130e02f8c8326a3bd633295c4b733