### PR TITLE
Update auth tests for new user name display

### DIFF
--- a/frontend/js/__tests__/auth.test.js
+++ b/frontend/js/__tests__/auth.test.js
@@ -383,7 +383,7 @@ describe('auth helpers', () => {
                 expiresAt,
             });
             expect(elements.panel.classList.contains('hidden')).toBe(false);
-            expect(elements.userRole.textContent).toBe('Usuario');
+            expect(elements.userNameDisplay.textContent).toBe('Luis');
         });
     });
 
@@ -453,8 +453,8 @@ describe('auth helpers', () => {
             expect(elements.panel.classList.contains('hidden')).toBe(true);
             expect(elements.logoutButton.disabled).toBe(true);
 
-            expect(elements.userLabel.textContent).toBe('');
-            expect(elements.userRole.textContent).toBe('');
+            expect(elements.userNameDisplay.textContent).toBe('');
+            expect(elements.userNameDisplay.classList.contains('hidden')).toBe(true);
         });
     });
 


### PR DESCRIPTION
## Summary
- update the persistAuth test that runs without localStorage to validate the new user name menu display
- adjust the clearStoredAuth test without storage to assert the user name display is cleared and remains hidden

## Testing
- npm test *(fails: existing auth helper tests currently fail in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d13494bc788326bb23c9e4dabf5915