### PR TITLE
Remove stray closing template tag

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -300,7 +300,6 @@
 
                             <div class="sm:col-span-2 stage-actions stage-actions--toggle"></div>
                         </div>
-                    </template>
                     <!-- Sanitización -->
                     <hr class="my-4">
                     <div class="grid grid-cols-1 sm:grid-cols-6 gap-x-4 gap-y-2 items-center py-2">


### PR DESCRIPTION
## Summary
- delete an orphan closing `</template>` tag from `frontend/index.html` to fix the build

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d13c8469248326b5da8464f886db5c