### PR TITLE
Implementar generación de remito desde el último mantenimiento

### DIFF
--- a/frontend/js/__tests__/main.test.js
+++ b/frontend/js/__tests__/main.test.js
@@ -2,25 +2,33 @@ import { jest } from '@jest/globals';
 
 const REPORT_NUMBER = 'REP-TEST-123456';
 
-describe('handleGuardarClick', () => {
+describe('event handlers en main.js', () => {
     let handleGuardarClick;
+    let handleGenerarRemitoClick;
     let guardarMantenimientoMock;
     let setReportNumberMock;
     let resetFormMock;
     let generateReportNumberMock;
     let getFormDataMock;
     let formData;
+    let storeLastSavedReportMock;
+    let renderRemitoFromStoredMock;
 
     beforeEach(async () => {
         jest.resetModules();
         jest.useFakeTimers();
 
-        formData = { cliente: 'Test' };
+        formData = {
+            cliente: 'ACME',
+            direccion: 'Av Siempre Viva 123',
+        };
         guardarMantenimientoMock = jest.fn().mockResolvedValue(undefined);
         setReportNumberMock = jest.fn();
         resetFormMock = jest.fn();
         generateReportNumberMock = jest.fn().mockReturnValue(REPORT_NUMBER);
         getFormDataMock = jest.fn().mockReturnValue(formData);
+        storeLastSavedReportMock = jest.fn();
+        renderRemitoFromStoredMock = jest.fn();
 
         jest.unstable_mockModule('../config.js', () => ({
             API_URL: 'http://localhost/api',
@@ -64,13 +72,15 @@ describe('handleGuardarClick', () => {
             renderDashboard: jest.fn(),
         }));
 
-        const mainModule = await import('../main.js');
-        ({ handleGuardarClick } = mainModule.__testables__);
+        jest.unstable_mockModule('../remito.js', () => ({
+            storeLastSavedReport: storeLastSavedReportMock,
+            renderRemitoFromStored: renderRemitoFromStoredMock,
+        }));
 
-        document.body.innerHTML = `
-            <button id="guardarButton">Guardar</button>
-            <button id="generarRemitoButton" disabled>Generar Remito</button>
-        `;
+        const mainModule = await import('../main.js');
+        ({ handleGuardarClick, handleGenerarRemitoClick } = mainModule.__testables__);
+
+        document.body.innerHTML = '';
         window.alert = jest.fn();
         window.print = jest.fn();
 
@@ -84,6 +94,18 @@ describe('handleGuardarClick', () => {
     });
 
     test('usa el mismo número de reporte para guardar y mostrar', async () => {
+        document.body.innerHTML = `
+            <select id="cliente">
+                <option value="ACME" selected>ACME S.A.</option>
+            </select>
+            <input id="direccion" value="Av Siempre Viva 123" />
+            <input id="cliente_telefono" value="123456789" />
+            <input id="cliente_email" value="soporte@example.com" />
+            <input id="cliente_cuit" value="20-12345678-9" />
+            <button id="guardarButton">Guardar</button>
+            <button id="generarRemitoButton" disabled>Generar Remito</button>
+        `;
+
         const generarRemitoButton = document.getElementById('generarRemitoButton');
         expect(generarRemitoButton).not.toBeNull();
         expect(generarRemitoButton.disabled).toBe(true);
@@ -96,6 +118,14 @@ describe('handleGuardarClick', () => {
         expect(formData.numero_reporte).toBe(REPORT_NUMBER);
         expect(guardarMantenimientoMock).toHaveBeenCalledWith(formData);
         expect(setReportNumberMock).toHaveBeenCalledWith(REPORT_NUMBER);
+        expect(storeLastSavedReportMock).toHaveBeenCalledTimes(1);
+        expect(storeLastSavedReportMock).toHaveBeenCalledWith(formData, {
+            clienteNombre: 'ACME S.A.',
+            clienteDireccion: 'Av Siempre Viva 123',
+            clienteTelefono: '123456789',
+            clienteEmail: 'soporte@example.com',
+            clienteCuit: '20-12345678-9',
+        });
 
         expect(generarRemitoButton.disabled).toBe(false);
 
@@ -111,5 +141,103 @@ describe('handleGuardarClick', () => {
         jest.runAllTimers();
         expect(window.print).toHaveBeenCalledTimes(1);
         expect(resetFormMock).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('handleGenerarRemitoClick', () => {
+    let handleGenerarRemitoClick;
+    let renderRemitoFromStoredMock;
+
+    beforeEach(async () => {
+        jest.resetModules();
+        renderRemitoFromStoredMock = jest.fn();
+
+        jest.unstable_mockModule('../config.js', () => ({
+            API_URL: 'http://localhost/api',
+        }));
+
+        jest.unstable_mockModule('../forms.js', () => ({
+            configureClientSelect: jest.fn(),
+            generateReportNumber: jest.fn(),
+            getFormData: jest.fn(),
+            initializeForm: jest.fn(),
+            resetForm: jest.fn(),
+            setReportNumber: jest.fn(),
+        }));
+
+        jest.unstable_mockModule('../api.js', () => ({
+            guardarMantenimiento: jest.fn(),
+            buscarMantenimientos: jest.fn(),
+            actualizarMantenimiento: jest.fn(),
+            eliminarMantenimiento: jest.fn(),
+            obtenerDashboard: jest.fn(),
+            obtenerClientes: jest.fn().mockResolvedValue([]),
+        }));
+
+        jest.unstable_mockModule('../auth.js', () => ({
+            initializeAuth: jest.fn(),
+        }));
+
+        jest.unstable_mockModule('../templates.js', () => ({
+            renderComponentStages: jest.fn(),
+        }));
+
+        jest.unstable_mockModule('../search.js', () => ({
+            clearSearchResults: jest.fn(),
+            getEditFormValues: jest.fn(),
+            openEditModal: jest.fn(),
+            closeEditModal: jest.fn(),
+            renderSearchResults: jest.fn(),
+        }));
+
+        jest.unstable_mockModule('../dashboard.js', () => ({
+            renderDashboard: jest.fn(),
+        }));
+
+        jest.unstable_mockModule('../remito.js', () => ({
+            storeLastSavedReport: jest.fn(),
+            renderRemitoFromStored: renderRemitoFromStoredMock,
+        }));
+
+        const mainModule = await import('../main.js');
+        ({ handleGenerarRemitoClick } = mainModule.__testables__);
+
+        window.alert = jest.fn();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('muestra el remito y oculta el formulario cuando hay datos disponibles', () => {
+        renderRemitoFromStoredMock.mockReturnValue(true);
+
+        document.body.innerHTML = `
+            <div id="tab-nuevo">Formulario</div>
+            <div id="remito-servicio" class="hidden">Remito</div>
+        `;
+
+        handleGenerarRemitoClick();
+
+        expect(renderRemitoFromStoredMock).toHaveBeenCalledTimes(1);
+        expect(document.getElementById('tab-nuevo').classList.contains('hidden')).toBe(true);
+        expect(document.getElementById('remito-servicio').classList.contains('hidden')).toBe(false);
+        expect(window.alert).not.toHaveBeenCalled();
+    });
+
+    test('muestra una alerta si no hay datos para generar el remito', () => {
+        renderRemitoFromStoredMock.mockReturnValue(false);
+
+        document.body.innerHTML = `
+            <div id="tab-nuevo">Formulario</div>
+            <div id="remito-servicio" class="hidden">Remito</div>
+        `;
+
+        handleGenerarRemitoClick();
+
+        expect(renderRemitoFromStoredMock).toHaveBeenCalledTimes(1);
+        expect(window.alert).toHaveBeenCalledWith('Primero guarda el mantenimiento para generar el remito.');
+        expect(document.getElementById('tab-nuevo').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('remito-servicio').classList.contains('hidden')).toBe(true);
     });
 });

--- a/frontend/js/__tests__/remito.test.js
+++ b/frontend/js/__tests__/remito.test.js
@@ -1,0 +1,129 @@
+import { storeLastSavedReport, renderRemitoFromStored } from '../remito.js';
+
+function setupRemitoDom() {
+    document.body.innerHTML = `
+        <span id="remito-numero"></span>
+        <span id="remito-fecha"></span>
+        <span id="remito-cliente"></span>
+        <span id="remito-cliente-direccion"></span>
+        <span id="remito-cliente-telefono"></span>
+        <span id="remito-cliente-email"></span>
+        <span id="remito-cliente-cuit"></span>
+        <span id="remito-equipo"></span>
+        <span id="remito-equipo-modelo"></span>
+        <span id="remito-equipo-serie"></span>
+        <span id="remito-equipo-interno"></span>
+        <span id="remito-equipo-ubicacion"></span>
+        <span id="remito-equipo-tecnico"></span>
+        <textarea id="remito-observaciones"></textarea>
+        <table><tbody id="remito-repuestos"></tbody></table>
+    `;
+}
+
+describe('remito.js', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('no renderiza la vista si no hay reporte almacenado', () => {
+        setupRemitoDom();
+        expect(renderRemitoFromStored()).toBe(false);
+    });
+
+    test('completa los datos del remito usando el último reporte guardado', () => {
+        setupRemitoDom();
+
+        const reporte = {
+            numero_reporte: 'REP-2024-0001',
+            fecha: '2024-05-20',
+            cliente: 'Cliente Base',
+            direccion: 'Av. Central 1000',
+            modelo: 'Modelo X',
+            n_serie: 'SN-001',
+            id_interna: 'INT-001',
+            tecnico: 'Juan Pérez',
+            resumen: 'Se realizó el mantenimiento anual completo.',
+            etapa1_detalles: 'COD123 - Cartucho Sedimentos 5µ',
+            etapa1_accion: 'Cambiado',
+            etapa2_detalles: '',
+            etapa2_accion: 'Inspeccionado',
+        };
+
+        const contexto = {
+            clienteNombre: 'Cliente Base S.A.',
+            clienteDireccion: 'Av. Central 1000',
+            clienteTelefono: '123456789',
+            clienteEmail: 'contacto@cliente.com',
+            clienteCuit: '30-12345678-9',
+        };
+
+        storeLastSavedReport(reporte, contexto);
+        reporte.modelo = 'Modelo Y';
+
+        expect(renderRemitoFromStored()).toBe(true);
+
+        expect(document.getElementById('remito-numero').textContent).toBe('REP-2024-0001');
+        expect(document.getElementById('remito-fecha').textContent).toBe('20/05/2024');
+        expect(document.getElementById('remito-cliente').textContent).toBe('Cliente Base S.A.');
+        expect(document.getElementById('remito-cliente-direccion').textContent).toBe('Av. Central 1000');
+        expect(document.getElementById('remito-cliente-telefono').textContent).toBe('123456789');
+        expect(document.getElementById('remito-cliente-email').textContent).toBe('contacto@cliente.com');
+        expect(document.getElementById('remito-cliente-cuit').textContent).toBe('30-12345678-9');
+        expect(document.getElementById('remito-equipo').textContent).toBe('Modelo X');
+        expect(document.getElementById('remito-equipo-modelo').textContent).toBe('Modelo X');
+        expect(document.getElementById('remito-equipo-serie').textContent).toBe('SN-001');
+        expect(document.getElementById('remito-equipo-interno').textContent).toBe('INT-001');
+        expect(document.getElementById('remito-equipo-ubicacion').textContent).toBe('Av. Central 1000');
+        expect(document.getElementById('remito-equipo-tecnico').textContent).toBe('Juan Pérez');
+
+        const observaciones = document.getElementById('remito-observaciones');
+        expect(observaciones.value).toBe('Se realizó el mantenimiento anual completo.');
+        expect(observaciones.readOnly).toBe(true);
+
+        const repuestosBody = document.getElementById('remito-repuestos');
+        expect(repuestosBody.children).toHaveLength(1);
+        const [repuestoRow] = repuestosBody.children;
+        const cells = repuestoRow.querySelectorAll('td');
+        expect(cells).toHaveLength(3);
+        expect(cells[0].textContent).toBe('COD123');
+        expect(cells[1].textContent).toBe('Cartucho Sedimentos 5µ');
+        expect(cells[2].textContent).toBe('1');
+    });
+
+    test('muestra mensaje cuando no hay repuestos cambiados y permite editar observaciones vacías', () => {
+        setupRemitoDom();
+
+        storeLastSavedReport(
+            {
+                numero_reporte: 'REP-2024-0002',
+                fecha: '2024-06-10',
+                cliente: 'Cliente B',
+                direccion: 'Calle Falsa 123',
+                resumen: '',
+                etapa1_accion: 'Inspeccionado',
+            },
+            {
+                clienteNombre: '',
+                clienteDireccion: '',
+                clienteTelefono: '',
+                clienteEmail: '',
+                clienteCuit: '',
+            },
+        );
+
+        expect(renderRemitoFromStored()).toBe(true);
+
+        const repuestosBody = document.getElementById('remito-repuestos');
+        expect(repuestosBody.children).toHaveLength(1);
+        const mensaje = repuestosBody.querySelector('td');
+        expect(mensaje.textContent).toBe('No se registraron repuestos cambiados en este mantenimiento.');
+        expect(mensaje.colSpan).toBe(3);
+
+        const observaciones = document.getElementById('remito-observaciones');
+        expect(observaciones.value).toBe('');
+        expect(observaciones.readOnly).toBe(false);
+
+        expect(document.getElementById('remito-cliente-telefono').textContent).toBe('---');
+        expect(document.getElementById('remito-cliente-email').textContent).toBe('---');
+    });
+});

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -6,6 +6,7 @@ import { renderDashboard } from './dashboard.js';
 import { configureClientSelect, generateReportNumber, getFormData, initializeForm, resetForm, setReportNumber } from './forms.js';
 import { clearSearchResults, getEditFormValues, openEditModal, closeEditModal, renderSearchResults } from './search.js';
 import { renderComponentStages } from './templates.js';
+import { storeLastSavedReport, renderRemitoFromStored } from './remito.js';
 
 const isApiConfigured = typeof API_URL === 'string' && API_URL.length > 0;
 
@@ -70,6 +71,20 @@ async function handleGuardarClick() {
         }
 
         await guardarMantenimiento(datos);
+        const clienteSelect = document.getElementById('cliente');
+        const clienteOption = clienteSelect?.selectedOptions?.[0] || null;
+        const direccionInput = document.getElementById('direccion');
+        const telefonoInput = document.getElementById('cliente_telefono');
+        const emailInput = document.getElementById('cliente_email');
+        const cuitInput = document.getElementById('cliente_cuit');
+
+        storeLastSavedReport(datos, {
+            clienteNombre: clienteOption ? clienteOption.textContent : datos.cliente,
+            clienteDireccion: direccionInput?.value ?? datos.direccion,
+            clienteTelefono: telefonoInput?.value ?? '',
+            clienteEmail: emailInput?.value ?? '',
+            clienteCuit: cuitInput?.value ?? '',
+        });
         alert('✅ Mantenimiento guardado correctamente en el sistema');
 
         if (generarRemitoBtn) {
@@ -97,8 +112,27 @@ async function handleGuardarClick() {
     }
 }
 
+function handleGenerarRemitoClick() {
+    const wasRendered = renderRemitoFromStored();
+    if (!wasRendered) {
+        alert('Primero guarda el mantenimiento para generar el remito.');
+        return;
+    }
+
+    const formView = document.getElementById('tab-nuevo');
+    if (formView) {
+        formView.classList.add('hidden');
+    }
+
+    const remitoView = document.getElementById('remito-servicio');
+    if (remitoView) {
+        remitoView.classList.remove('hidden');
+    }
+}
+
 export const __testables__ = {
     handleGuardarClick,
+    handleGenerarRemitoClick,
 };
 
 async function handleBuscarClick() {
@@ -190,6 +224,11 @@ function attachEventListeners() {
     const resetBtn = document.getElementById('resetButton');
     if (resetBtn) {
         resetBtn.addEventListener('click', resetForm);
+    }
+
+    const generarRemitoBtn = document.getElementById('generarRemitoButton');
+    if (generarRemitoBtn) {
+        generarRemitoBtn.addEventListener('click', handleGenerarRemitoClick);
     }
 
     const buscarBtn = document.getElementById('buscar-btn');

--- a/frontend/js/remito.js
+++ b/frontend/js/remito.js
@@ -1,0 +1,259 @@
+import { normalizeDateToISO } from './forms.js';
+import { COMPONENT_STAGES } from './templates.js';
+
+const TEXT_PLACEHOLDER = '---';
+const DATE_PLACEHOLDER = '--/--/----';
+const NO_PARTS_MESSAGE = 'No se registraron repuestos cambiados en este mantenimiento.';
+const TABLE_CODE_PLACEHOLDER = '—';
+
+const DEFAULT_CONTEXT = Object.freeze({
+    clienteNombre: '',
+    clienteDireccion: '',
+    clienteTelefono: '',
+    clienteEmail: '',
+    clienteCuit: '',
+});
+
+let storedReport = null;
+let storedContext = { ...DEFAULT_CONTEXT };
+
+function normalizeText(value) {
+    if (value === null || value === undefined) {
+        return '';
+    }
+
+    if (typeof value === 'string') {
+        return value.trim();
+    }
+
+    return String(value).trim();
+}
+
+function sanitizeContext(context = {}) {
+    const cleanContext = { ...DEFAULT_CONTEXT };
+
+    if (!context || typeof context !== 'object') {
+        return cleanContext;
+    }
+
+    Object.keys(cleanContext).forEach(key => {
+        if (Object.prototype.hasOwnProperty.call(context, key)) {
+            cleanContext[key] = normalizeText(context[key]);
+        }
+    });
+
+    return cleanContext;
+}
+
+function formatDateForDisplay(value) {
+    const isoDate = normalizeDateToISO(value);
+    if (!isoDate) {
+        return '';
+    }
+
+    const [year, month, day] = isoDate.split('-');
+    if (!year || !month || !day) {
+        return '';
+    }
+
+    const paddedDay = day.padStart(2, '0');
+    const paddedMonth = month.padStart(2, '0');
+    return `${paddedDay}/${paddedMonth}/${year}`;
+}
+
+function setTextContent(elementId, value, { placeholder = TEXT_PLACEHOLDER } = {}) {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    const element = document.getElementById(elementId);
+    if (!element) {
+        return;
+    }
+
+    const normalized = normalizeText(value);
+    element.textContent = normalized || placeholder;
+}
+
+function setObservacionesValue(report) {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    const textarea = document.getElementById('remito-observaciones');
+    if (!(textarea instanceof HTMLTextAreaElement)) {
+        return;
+    }
+
+    const resumen = normalizeText(report?.resumen);
+    textarea.value = resumen;
+
+    if (resumen) {
+        textarea.readOnly = true;
+        textarea.setAttribute('readonly', 'readonly');
+    } else {
+        textarea.readOnly = false;
+        textarea.removeAttribute('readonly');
+    }
+}
+
+function extractCodeAndDescription(detail) {
+    const normalized = normalizeText(detail);
+    if (!normalized) {
+        return {
+            code: '',
+            description: '',
+        };
+    }
+
+    const separators = [' - ', '-', ':', '|'];
+    for (const separator of separators) {
+        const index = normalized.indexOf(separator);
+        if (index > 0) {
+            const code = normalizeText(normalized.slice(0, index));
+            const description = normalizeText(normalized.slice(index + separator.length));
+            if (code && description) {
+                return { code, description };
+            }
+        }
+    }
+
+    return {
+        code: '',
+        description: normalized,
+    };
+}
+
+function renderRepuestos(report) {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    const tableBody = document.getElementById('remito-repuestos');
+    if (!tableBody) {
+        return;
+    }
+
+    tableBody.innerHTML = '';
+
+    if (!report || typeof report !== 'object') {
+        return;
+    }
+
+    let rowsRendered = 0;
+
+    COMPONENT_STAGES.forEach(stage => {
+        const actionKey = `${stage.id}_accion`;
+        const detailsKey = `${stage.id}_detalles`;
+        const action = normalizeText(report[actionKey]).toLowerCase();
+
+        if (action !== 'cambiado') {
+            return;
+        }
+
+        const { code, description } = extractCodeAndDescription(report[detailsKey]);
+
+        const row = document.createElement('tr');
+
+        const codeCell = document.createElement('td');
+        codeCell.className = 'px-4 py-2 text-sm text-gray-700 whitespace-nowrap';
+        codeCell.textContent = code || TABLE_CODE_PLACEHOLDER;
+
+        const descriptionCell = document.createElement('td');
+        descriptionCell.className = 'px-4 py-2 text-sm text-gray-700';
+        descriptionCell.textContent = description || stage.title;
+
+        const quantityCell = document.createElement('td');
+        quantityCell.className = 'px-4 py-2 text-sm text-right text-gray-700';
+        quantityCell.textContent = '1';
+
+        row.append(codeCell, descriptionCell, quantityCell);
+        tableBody.appendChild(row);
+        rowsRendered += 1;
+    });
+
+    if (rowsRendered === 0) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 3;
+        cell.className = 'px-4 py-3 text-sm text-gray-500 text-center';
+        cell.textContent = NO_PARTS_MESSAGE;
+        row.appendChild(cell);
+        tableBody.appendChild(row);
+    }
+}
+
+function populateRemito(report, context = DEFAULT_CONTEXT) {
+    if (!report || typeof report !== 'object') {
+        return;
+    }
+
+    const sanitizedContext = sanitizeContext(context);
+
+    setTextContent('remito-numero', report.numero_reporte);
+
+    const displayDate = formatDateForDisplay(report.fecha);
+    setTextContent('remito-fecha', displayDate, { placeholder: DATE_PLACEHOLDER });
+
+    const clienteNombre = sanitizedContext.clienteNombre || report.cliente;
+    setTextContent('remito-cliente', clienteNombre);
+
+    const clienteDireccion = sanitizedContext.clienteDireccion || report.direccion;
+    setTextContent('remito-cliente-direccion', clienteDireccion);
+
+    setTextContent('remito-cliente-telefono', sanitizedContext.clienteTelefono);
+    setTextContent('remito-cliente-email', sanitizedContext.clienteEmail);
+    setTextContent('remito-cliente-cuit', sanitizedContext.clienteCuit);
+
+    const modelo = report.modelo;
+    setTextContent('remito-equipo', modelo);
+    setTextContent('remito-equipo-modelo', modelo);
+    setTextContent('remito-equipo-serie', report.n_serie);
+    setTextContent('remito-equipo-interno', report.id_interna);
+
+    const ubicacion = sanitizedContext.clienteDireccion || report.direccion;
+    setTextContent('remito-equipo-ubicacion', ubicacion);
+    setTextContent('remito-equipo-tecnico', report.tecnico);
+
+    setObservacionesValue(report);
+    renderRepuestos(report);
+}
+
+export function storeLastSavedReport(report, context = {}) {
+    if (!report || typeof report !== 'object') {
+        storedReport = null;
+        storedContext = { ...DEFAULT_CONTEXT };
+        return;
+    }
+
+    try {
+        storedReport = JSON.parse(JSON.stringify(report));
+    } catch (error) {
+        storedReport = { ...report };
+    }
+
+    storedContext = sanitizeContext(context);
+}
+
+export function renderRemitoFromStored() {
+    if (typeof document === 'undefined') {
+        return false;
+    }
+
+    if (!storedReport) {
+        return false;
+    }
+
+    populateRemito(storedReport, storedContext);
+    return true;
+}
+
+export const __testables__ = {
+    formatDateForDisplay,
+    extractCodeAndDescription,
+    sanitizeContext,
+    populateRemito,
+    setObservacionesValue,
+    getStoredReport: () => storedReport,
+    getStoredContext: () => ({ ...storedContext }),
+};


### PR DESCRIPTION
## Resumen
- crear un módulo dedicado a poblar la vista del remito con los datos del último mantenimiento y marcar los campos autocompletados como de solo lectura
- almacenar los datos guardados desde el formulario y mostrar la vista del remito cuando se presiona el botón correspondiente
- añadir pruebas unitarias para los nuevos flujos y la generación de remitos

## Pruebas
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3fd2f6ba48326b755e328654f4f0a