### PR TITLE
Remove unused handleSanitizacionClick binding from test

### DIFF
--- a/frontend/js/__tests__/main.test.js
+++ b/frontend/js/__tests__/main.test.js
@@ -65,7 +65,7 @@ describe('handleGuardarClick', () => {
         }));
 
         const mainModule = await import('../main.js');
-        ({ handleGuardarClick } = mainModule.__testables__);
+        handleGuardarClick = mainModule.__testables__.handleGuardarClick;
 
         document.body.innerHTML = `
             <button id="guardarButton">Guardar</button>


### PR DESCRIPTION
## Summary
- replace the destructured assignment in `frontend/js/__tests__/main.test.js` with a direct property access so only `handleGuardarClick` is bound

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d407ffab648326a61dae923e538850