### PR TITLE
Add remito view toggle and population from saved maintenance data

### DIFF
--- a/frontend/css/styles.build.css
+++ b/frontend/css/styles.build.css
@@ -612,70 +612,6 @@ video {
   }
 }
 
-
-.user-menu-toggle {
-  display: flex;
-  height: 2.5rem;
-  width: 2.5rem;
-  align-items: center;
-  justify-content: center;
-  border-radius: 9999px;
-  border-width: 1px;
-  --tw-border-opacity: 1;
-  border-color: rgb(226 232 240 / var(--tw-border-opacity, 1));
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
-  --tw-text-opacity: 1;
-  color: rgb(100 116 139 / var(--tw-text-opacity, 1));
-  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
-  transition-property: box-shadow;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 200ms;
-  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-}
-
-.user-menu-toggle:hover {
-  --tw-text-opacity: 1;
-  color: rgb(51 65 85 / var(--tw-text-opacity, 1));
-  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
-.user-menu-toggle:focus-visible {
-  outline: 2px solid transparent;
-  outline-offset: 2px;
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-  --tw-ring-opacity: 1;
-
-  --tw-ring-color: rgb(248 113 113 / var(--tw-ring-opacity, 1));
-  --tw-ring-offset-width: 2px;
-}
-
-.session-info__logout-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-.session-info__logout-button:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(220 38 38 / var(--tw-bg-opacity, 1));
-}
-
-.session-info__logout-button:focus-visible {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(252 165 165 / var(--tw-ring-opacity, 1));
-}
-
-.app-container {
-  min-height: 100vh;
-}
-
 .login-container {
   display: flex;
   min-height: 100vh;
@@ -758,50 +694,10 @@ video {
   border-width: 1px;
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
-
-  --tw-ring-color: rgb(59 130 246 / var(--tw-ring-opacity, 1));
-  --tw-ring-offset-width: 2px;
-}
-
-.user-menu {
-  position: absolute;
-  right: 0px;
-  top: 100%;
-  z-index: 30;
-  margin-top: 0.75rem;
-  width: 14rem;
-  overflow: hidden;
-  border-radius: 1rem;
-  border-width: 1px;
-  --tw-border-opacity: 1;
-  border-color: rgb(241 245 249 / var(--tw-border-opacity, 1));
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
-  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  max-width: min(18rem, calc(100vw - 1.5rem));
-}
-
-.user-menu__content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.5rem;
-}
-
-.user-menu__item {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  gap: 0.75rem;
-  border-radius: 0.75rem;
-
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
-
   font-size: 1rem;
   line-height: 1.5rem;
   --tw-text-opacity: 1;
@@ -828,12 +724,10 @@ video {
 }
 
 .login-error {
-
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
   --tw-text-opacity: 1;
-
   color: rgb(220 38 38 / var(--tw-text-opacity, 1));
 }
 
@@ -914,29 +808,12 @@ video {
 }
 
 .tab-button:focus-visible {
-
-  color: rgb(71 85 105 / var(--tw-text-opacity, 1));
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-}
-
-.user-menu__item:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(241 245 249 / var(--tw-bg-opacity, 1));
-  --tw-text-opacity: 1;
-  color: rgb(15 23 42 / var(--tw-text-opacity, 1));
-}
-
-.user-menu__item:focus-visible {
-
   outline: 2px solid transparent;
   outline-offset: 2px;
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
   --tw-ring-opacity: 1;
-
   --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity, 1));
   --tw-ring-offset-width: 2px;
 }
@@ -1086,187 +963,6 @@ video {
   margin-top: 1.5rem;
 }
 
-.toggle-switch {
-  position: relative;
-  display: inline-flex;
-  height: 1.5rem;
-  width: 2.75rem;
-  flex-shrink: 0;
-  cursor: pointer;
-  align-items: center;
-}
-
-.toggle-switch-input {
-
-  --tw-ring-color: rgb(59 130 246 / var(--tw-ring-opacity, 1));
-  --tw-ring-offset-width: 2px;
-}
-
-.user-menu__item:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-.user-menu__logout {
-  --tw-text-opacity: 1;
-  color: rgb(220 38 38 / var(--tw-text-opacity, 1));
-}
-
-.user-menu__logout:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 242 242 / var(--tw-bg-opacity, 1));
-  --tw-text-opacity: 1;
-  color: rgb(185 28 28 / var(--tw-text-opacity, 1));
-}
-
-.user-menu__logout:focus-visible {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(239 68 68 / var(--tw-ring-opacity, 1));
-}
-
-.form-card > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-y-reverse: 0;
-  margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(1rem * var(--tw-space-y-reverse));
-}
-
-.form-card {
-  border-radius: 0.75rem;
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
-  padding: 1.5rem;
-  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
-.status-pass {
-  background-color: rgb(220 252 231);
-  color: rgb(22 101 52);
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.status-fail {
-  background-color: rgb(254 226 226);
-  color: rgb(153 27 27);
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.status-na {
-  background-color: rgb(229 231 235);
-  color: rgb(55 65 81);
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.component-toggle {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  align-items: stretch;
-  width: 100%;
-  border-radius: 9999px;
-  overflow: hidden;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: rgb(75 85 99);
-}
-
-.component-toggle__track {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background-color: rgb(229 231 235);
-  transition: background-color 0.2s ease;
-  z-index: 1;
-}
-
-.component-toggle__thumb {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 50%;
-  border-radius: inherit;
-  background-color: #ffffff;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
-  transition: transform 0.25s ease;
-  z-index: 2;
-}
-
-.component-toggle[data-state="cambiado"] .component-toggle__thumb {
-  transform: translateX(0%);
-}
-
-.component-toggle[data-state="inspeccionado"] .component-toggle__thumb {
-  transform: translateX(100%);
-}
-
-.component-toggle__input {
-
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-
-  white-space: nowrap;
-  border-width: 0;
-}
-
-.toggle-switch-slider {
-  position: relative;
-  display: inline-block;
-  height: 100%;
-  width: 100%;
-  border-radius: 9999px;
-  --tw-bg-opacity: 1;
-  background-color: rgb(209 213 219 / var(--tw-bg-opacity, 1));
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
-  transition-duration: 200ms;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.toggle-switch-slider::after {
-  content: '';
-  position: absolute;
-  top: 0.125rem;
-  left: 0.125rem;
-  width: 1.25rem;
-  height: 1.25rem;
-  border-radius: 9999px;
-  background-color: #fff;
-  box-shadow: 0 2px 4px rgb(15 23 42 / 0.2);
-  transition: transform 0.2s ease-in-out;
-}
-
-.toggle-switch-input:checked + .toggle-switch-slider {
-  --tw-bg-opacity: 1;
-  background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
-}
-
-.toggle-switch-input:checked + .toggle-switch-slider::after {
-  transform: translateX(1.25rem);
-}
-
-.toggle-switch-input:focus-visible + .toggle-switch-slider {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity, 1));
-  --tw-ring-offset-width: 2px;
-}
-
-.stage-action-status {
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  font-weight: 500;
-  --tw-text-opacity: 1;
-  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
-}
-
 .sanitizacion-toggle {
   display: inline-flex;
   width: 100%;
@@ -1284,91 +980,11 @@ video {
 }
 
 .sanitizacion-toggle-option {
-
-  clip-path: inset(50%);
-  border: 0;
-  white-space: nowrap;
-}
-
-.component-toggle__option {
-  position: relative;
-  z-index: 5;
-  cursor: pointer;
-  padding: 0.75rem 0.5rem;
-  text-align: center;
-  color: rgb(107 114 128);
-  transition: color 0.2s ease, font-weight 0.2s ease;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.component-toggle__option:hover {
-  color: rgb(55 65 81);
-}
-
-.component-toggle[data-state="cambiado"] .component-toggle__option--cambiado,
-    .component-toggle[data-state="inspeccionado"] .component-toggle__option--inspeccionado {
-  color: rgb(17 24 39);
-  font-weight: 600;
-}
-
-.sanitizacion-options {
-  --sanitizacion-border: rgb(209 213 219);
-  --sanitizacion-background: rgb(249 250 251);
-  --sanitizacion-active-bg: rgb(229 231 235);
-  --sanitizacion-active-color: rgb(55 65 81);
-  --sanitizacion-active-border: rgba(107, 114, 128, 0.35);
-  --sanitizacion-active-shadow: rgba(55, 65, 81, 0.15);
-  display: flex;
-  width: 100%;
-  border-radius: 9999px;
-  border: 1px solid var(--sanitizacion-border);
-  background-color: var(--sanitizacion-background);
-  overflow: hidden;
-  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
-  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.sanitizacion-options[data-status="success"] {
-  --sanitizacion-border: rgb(134 239 172);
-  --sanitizacion-background: rgb(240 253 244);
-  --sanitizacion-active-bg: rgb(220 252 231);
-  --sanitizacion-active-color: rgb(22 101 52);
-  --sanitizacion-active-border: rgba(34, 197, 94, 0.45);
-  --sanitizacion-active-shadow: rgba(22, 101, 52, 0.25);
-}
-
-.sanitizacion-options[data-status="danger"] {
-  --sanitizacion-border: rgb(252 165 165);
-  --sanitizacion-background: rgb(254 242 242);
-  --sanitizacion-active-bg: rgb(254 226 226);
-  --sanitizacion-active-color: rgb(153 27 27);
-  --sanitizacion-active-border: rgba(248, 113, 113, 0.45);
-  --sanitizacion-active-shadow: rgba(153, 27, 27, 0.25);
-}
-
-.sanitizacion-options[data-status="neutral"] {
-  --sanitizacion-border: rgb(209 213 219);
-  --sanitizacion-background: rgb(249 250 251);
-  --sanitizacion-active-bg: rgb(229 231 235);
-  --sanitizacion-active-color: rgb(55 65 81);
-  --sanitizacion-active-border: rgba(107, 114, 128, 0.35);
-  --sanitizacion-active-shadow: rgba(55, 65, 81, 0.15);
-}
-
-.sanitizacion-option {
-
   position: relative;
   flex: 1 1 0%;
 }
 
-
-.sanitizacion-option input {
-
+.sanitizacion-toggle-option input {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -1376,41 +992,115 @@ video {
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
-
-  clip-path: inset(50%);
   white-space: nowrap;
-  border: 0;
+  border-width: 0;
 }
 
-.sanitizacion-option span {
+.sanitizacion-toggle-option span {
   display: block;
   width: 100%;
-  padding: 0.6rem 0.75rem;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-color: transparent;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
   text-align: center;
   font-size: 0.875rem;
-  font-weight: 500;
-  color: rgb(75 85 99);
-  border-left: 1px solid rgba(148, 163, 184, 0.25);
-  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
+  line-height: 1.25rem;
+  font-weight: 600;
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 }
 
-.sanitizacion-option:first-child span {
-  border-left-color: transparent;
+.sanitizacion-toggle-option input:not(:checked) + span {
+  background-color: transparent;
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
 }
 
-.sanitizacion-option input:not(:checked) + span:hover {
-  background-color: rgba(255, 255, 255, 0.6);
-  color: rgb(31 41 55);
+.sanitizacion-toggle-option input:not(:checked) + span:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
 }
 
-.sanitizacion-option input:checked + span {
-  color: var(--sanitizacion-active-color);
-  background-color: var(--sanitizacion-active-bg);
-  border-color: var(--sanitizacion-active-border);
-  box-shadow: inset 0 0 0 1px var(--sanitizacion-active-border), 0 6px 18px -10px var(--sanitizacion-active-shadow);
+.sanitizacion-toggle-option input:focus-visible + span {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity, 1));
+  --tw-ring-offset-width: 1px;
+}
+
+.sanitizacion-toggle-option[data-option='N/A'] input:checked + span {
+  border-color: transparent;
+  --tw-bg-opacity: 1;
+  background-color: rgb(100 116 139 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.sanitizacion-toggle-option[data-option='Realizada'] input:checked + span {
+  border-color: transparent;
+  --tw-bg-opacity: 1;
+  background-color: rgb(16 185 129 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.sanitizacion-toggle-option[data-option='No Realizada'] input:checked + span {
+  border-color: transparent;
+  --tw-bg-opacity: 1;
+  background-color: rgb(244 63 94 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.status-pass {
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(110 231 183 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(209 250 229 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(4 120 87 / var(--tw-text-opacity, 1));
+}
+
+.status-fail {
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(253 164 175 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 228 230 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(190 18 60 / var(--tw-text-opacity, 1));
+}
+
+.status-na {
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(203 213 225 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(241 245 249 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(51 65 85 / var(--tw-text-opacity, 1));
 }
 
 .sr-only {
@@ -1423,7 +1113,6 @@ video {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border-width: 0;
-
 }
 
 .fixed {
@@ -1442,11 +1131,6 @@ video {
   z-index: 40;
 }
 
-
-.z-50 {
-  z-index: 50;
-}
-
 .order-1 {
   order: 1;
 }
@@ -1458,7 +1142,6 @@ video {
 .order-3 {
   order: 3;
 }
-
 
 .mx-auto {
   margin-left: auto;
@@ -1486,6 +1169,10 @@ video {
   margin-bottom: 1.5rem;
 }
 
+.mb-8 {
+  margin-bottom: 2rem;
+}
+
 .ml-2 {
   margin-left: 0.5rem;
 }
@@ -1494,15 +1181,17 @@ video {
   margin-left: auto;
 }
 
-
 .mr-2 {
   margin-right: 0.5rem;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
 }
 
 .mt-2 {
   margin-top: 0.5rem;
 }
-
 
 .mt-6 {
   margin-top: 1.5rem;
@@ -1532,7 +1221,6 @@ video {
   display: none;
 }
 
-
 .h-14 {
   height: 3.5rem;
 }
@@ -1541,14 +1229,9 @@ video {
   height: 1.25rem;
 }
 
-
 .max-h-screen {
   max-height: 100vh;
 }
-
-
-.min-h-screen {
-  min-height: 100vh;
 
 .w-5 {
   width: 1.25rem;
@@ -1556,7 +1239,6 @@ video {
 
 .w-auto {
   width: auto;
-
 }
 
 .w-full {
@@ -1575,28 +1257,21 @@ video {
   max-width: 80rem;
 }
 
-
-.grid-cols-1 {
-  grid-template-columns: repeat(1, minmax(0, 1fr));
-
-.max-w-md {
-  max-width: 28rem;
-}
-
 .flex-shrink-0 {
   flex-shrink: 0;
-
 }
 
 .grid-cols-1 {
   grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 
+.flex-col {
+  flex-direction: column;
+}
 
 .flex-wrap {
   flex-wrap: wrap;
 }
-
 
 .items-end {
   align-items: flex-end;
@@ -1614,16 +1289,16 @@ video {
   justify-content: center;
 }
 
+.justify-between {
+  justify-content: space-between;
+}
+
 .gap-1 {
   gap: 0.25rem;
 }
 
 .gap-2 {
   gap: 0.5rem;
-}
-
-.gap-3 {
-  gap: 0.75rem;
 }
 
 .gap-3 {
@@ -1666,12 +1341,6 @@ video {
   --tw-space-x-reverse: 0;
   margin-right: calc(0.75rem * var(--tw-space-x-reverse));
   margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
-}
-
-.space-x-4 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-x-reverse: 0;
-  margin-right: calc(1rem * var(--tw-space-x-reverse));
-  margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
 .space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -1821,6 +1490,11 @@ video {
   text-align: center;
 }
 
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
 .text-3xl {
   font-size: 1.875rem;
   line-height: 2.25rem;
@@ -1862,6 +1536,10 @@ video {
   text-transform: uppercase;
 }
 
+.tracking-wide {
+  letter-spacing: 0.025em;
+}
+
 .text-blue-600 {
   --tw-text-opacity: 1;
   color: rgb(37 99 235 / var(--tw-text-opacity, 1));
@@ -1870,6 +1548,11 @@ video {
 .text-gray-500 {
   --tw-text-opacity: 1;
   color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+.text-gray-600 {
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
 }
 
 .text-gray-700 {
@@ -1921,6 +1604,11 @@ video {
 
 .filter {
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.odd\:bg-gray-50:nth-child(odd) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
 }
 
 .hover\:bg-blue-700:hover {
@@ -1982,6 +1670,29 @@ video {
     order: 2;
   }
 
+  .md\:order-3 {
+    order: 3;
+  }
+
+  .md\:col-span-1 {
+    grid-column: span 1 / span 1;
+  }
+
+  .md\:col-span-2 {
+    grid-column: span 2 / span 2;
+  }
+
+  .md\:h-16 {
+    height: 4rem;
+  }
+
+  .md\:flex-1 {
+    flex: 1 1 0%;
+  }
+
+  .md\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
 
   .md\:grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1995,36 +1706,16 @@ video {
     flex-direction: row;
   }
 
+  .md\:items-start {
+    align-items: flex-start;
+  }
+
   .md\:items-center {
     align-items: center;
   }
 
   .md\:justify-between {
     justify-content: space-between;
-
-  .md\:order-3 {
-    order: 3;
-  }
-
-  .md\:col-span-1 {
-    grid-column: span 1 / span 1;
-  }
-
-  .md\:h-16 {
-    height: 4rem;
-  }
-
-  .md\:flex-1 {
-    flex: 1 1 0%;
-  }
-
-  .md\:grid-cols-2 {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .md\:grid-cols-3 {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-
   }
 
   .md\:p-8 {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -59,6 +59,7 @@
 
         <!-- Pestaña: Nuevo Mantenimiento -->
         <div id="tab-nuevo" class="tab-content">
+            <div id="maintenance-view">
             <form id="maintenance-form">
                 <!-- Sección A: Datos del Servicio y del Equipo -->
 
@@ -336,11 +337,36 @@
                 </div>
 
                 <!-- Botones de Acción -->
-                <div class="flex justify-end space-x-4 mt-8 no-print">
+                <div class="flex flex-wrap justify-end gap-3 mt-8 no-print">
                     <button type="button" id="resetButton" class="action-button reset-btn">Limpiar Formulario</button>
+                    <button type="button" id="generarRemitoButton" class="action-button print-btn">Generar Remito</button>
                     <button type="button" id="guardarButton" class="action-button print-btn">Guardar y Generar Reporte</button>
                 </div>
             </form>
+            </div>
+
+            <div id="remito-view" class="hidden space-y-6">
+                <div class="form-card">
+                    <div class="form-section">
+                        <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+                            <div>
+                                <h2 class="text-2xl font-bold text-gray-800">Remito de Entrega</h2>
+                                <p class="text-gray-600 mt-1">Documento generado a partir del mantenimiento registrado.</p>
+                                <p class="text-gray-600 mt-2">
+                                    Reporte <span id="remito-report-number" class="font-semibold"></span>
+                                    &bull; Fecha del servicio: <span id="remito-report-date" class="font-semibold"></span>
+                                </p>
+                            </div>
+                            <div class="flex flex-wrap gap-3 no-print">
+                                <button type="button" id="volverFormularioButton" class="action-button reset-btn">Volver al Formulario</button>
+                                <button type="button" id="imprimirRemitoButton" class="action-button print-btn">Imprimir Remito</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div id="remito-sections" class="space-y-6"></div>
+            </div>
         </div>
 
         <!-- Pestaña: Buscar/Editar -->

--- a/frontend/js/__tests__/main.test.js
+++ b/frontend/js/__tests__/main.test.js
@@ -50,6 +50,7 @@ describe('handleGuardarClick', () => {
 
         jest.unstable_mockModule('../templates.js', () => ({
             renderComponentStages: jest.fn(),
+            COMPONENT_STAGES: [],
         }));
 
         jest.unstable_mockModule('../search.js', () => ({

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -5,12 +5,385 @@ import { guardarMantenimiento, buscarMantenimientos, actualizarMantenimiento, el
 import { renderDashboard } from './dashboard.js';
 import { configureClientSelect, generateReportNumber, getFormData, initializeForm, resetForm, setReportNumber } from './forms.js';
 import { clearSearchResults, getEditFormValues, openEditModal, closeEditModal, renderSearchResults } from './search.js';
-import { renderComponentStages } from './templates.js';
+import { renderComponentStages, COMPONENT_STAGES } from './templates.js';
 
 const isApiConfigured = typeof API_URL === 'string' && API_URL.length > 0;
 
 if (!isApiConfigured) {
     console.warn('API_URL no configurado. Configura window.__APP_CONFIG__.API_URL o la variable de entorno API_URL.');
+}
+
+let lastSavedReport = null;
+
+const REMITO_FIELD_GROUPS = [
+    {
+        type: 'fields',
+        title: 'Datos del Servicio',
+        columns: 2,
+        fields: [
+            { key: 'numero_reporte', label: 'Número de Reporte' },
+            { key: 'fecha', label: 'Fecha del Servicio', formatter: formatDateValue },
+            { key: 'proximo_mant', label: 'Próximo Mantenimiento', formatter: formatDateValue },
+            { key: 'tecnico', label: 'Técnico Asignado' },
+        ],
+    },
+    {
+        type: 'fields',
+        title: 'Datos del Cliente',
+        columns: 2,
+        fields: [
+            { key: 'cliente', label: 'Cliente' },
+            { key: 'direccion', label: 'Dirección' },
+            { key: 'cliente_telefono', label: 'Teléfono' },
+            { key: 'cliente_email', label: 'Email' },
+            { key: 'cliente_cuit', label: 'CUIT' },
+        ],
+    },
+    {
+        type: 'fields',
+        title: 'Datos del Equipo',
+        columns: 2,
+        fields: [
+            { key: 'modelo', label: 'Modelo del Equipo' },
+            { key: 'id_interna', label: 'ID Interna / Activo N°' },
+            { key: 'n_serie', label: 'Número de Serie' },
+        ],
+    },
+    {
+        type: 'pairs',
+        title: 'Parámetros de Operación',
+        description: 'Valores registrados antes (As Found) y después (As Left) del mantenimiento.',
+    },
+    {
+        type: 'components',
+        title: 'Registro de Componentes',
+        description: 'Detalle de las etapas intervenidas durante el mantenimiento.',
+    },
+    {
+        type: 'fields',
+        title: 'Sanitización y Resumen',
+        columns: 1,
+        fields: [
+            { key: 'sanitizacion', label: 'Sanitización del Sistema' },
+            { key: 'resumen', label: 'Resumen y Recomendaciones', multiline: true, rows: 6, fullWidth: true },
+        ],
+    },
+];
+
+const REMITO_PARAMETER_PAIRS = [
+    { label: 'Fugas visibles', foundKey: 'fugas_found', leftKey: 'fugas_left' },
+    { label: 'Conductividad Agua de Red (µS/cm)', foundKey: 'cond_red_found', leftKey: 'cond_red_left' },
+    { label: 'Conductividad Permeado (µS/cm)', foundKey: 'cond_perm_found', leftKey: 'cond_perm_left' },
+    { label: '% de Rechazo Iónico', foundKey: 'rechazo_found', leftKey: 'rechazo_left' },
+    { label: 'Presión Entrada a Membrana (bar)', foundKey: 'presion_found', leftKey: 'presion_left' },
+    { label: 'Caudal de Permeado (l/min)', foundKey: 'caudal_perm_found', leftKey: 'caudal_perm_left' },
+    { label: 'Caudal de Rechazo (l/min)', foundKey: 'caudal_rech_found', leftKey: 'caudal_rech_left' },
+    { label: 'Relación Rechazo : Permeado', foundKey: 'relacion_found', leftKey: 'relacion_left' },
+    { label: 'Precarga del tanque (bar)', foundKey: 'precarga_found', leftKey: 'precarga_left' },
+    { label: 'Test Presostato Alta', foundKey: 'presostato_alta_found', leftKey: 'presostato_alta_left' },
+    { label: 'Test Presostato Baja', foundKey: 'presostato_baja_found', leftKey: 'presostato_baja_left' },
+];
+
+function cloneReportData(data) {
+    if (!data || typeof data !== 'object') {
+        return {};
+    }
+    try {
+        return JSON.parse(JSON.stringify(data));
+    } catch (error) {
+        console.warn('No se pudo clonar el reporte para el remito:', error);
+        return { ...data };
+    }
+}
+
+function formatDateValue(value) {
+    if (!value) {
+        return '';
+    }
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+        return `${value}`.trim();
+    }
+
+    return parsed.toLocaleDateString('es-AR', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+    });
+}
+
+function formatDisplayValue(value) {
+    if (Array.isArray(value)) {
+        return value.map(item => formatDisplayValue(item)).join(', ');
+    }
+    if (value === null || value === undefined) {
+        return '';
+    }
+    return `${value}`.trim();
+}
+
+function createRemitoCardElements(title, description) {
+    const card = document.createElement('div');
+    card.className = 'form-card';
+
+    const section = document.createElement('div');
+    section.className = 'form-section';
+
+    if (title) {
+        const heading = document.createElement('h3');
+        heading.className = 'text-xl font-semibold text-gray-800 mb-4';
+        heading.textContent = title;
+        section.appendChild(heading);
+    }
+
+    if (description) {
+        const descriptionEl = document.createElement('p');
+        descriptionEl.className = 'text-sm text-gray-500 mb-4';
+        descriptionEl.textContent = description;
+        section.appendChild(descriptionEl);
+    }
+
+    card.appendChild(section);
+    return { card, section };
+}
+
+function createReadOnlyControl(value, { multiline = false, rows, id } = {}) {
+    const normalized = formatDisplayValue(value);
+
+    if (multiline) {
+        const textarea = document.createElement('textarea');
+        textarea.className = 'w-full border border-gray-300 rounded-md px-3 py-2 bg-gray-100 text-gray-800';
+        textarea.value = normalized;
+        textarea.readOnly = true;
+        textarea.setAttribute('aria-readonly', 'true');
+        textarea.rows = typeof rows === 'number' && rows > 0 ? rows : 4;
+        textarea.tabIndex = -1;
+        if (id) {
+            textarea.id = id;
+        }
+        return textarea;
+    }
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'w-full border border-gray-300 rounded-md px-3 py-2 bg-gray-100 text-gray-800';
+    input.value = normalized;
+    input.readOnly = true;
+    input.setAttribute('aria-readonly', 'true');
+    input.tabIndex = -1;
+    if (id) {
+        input.id = id;
+    }
+    return input;
+}
+
+function renderRemitoFieldsGroup(group, data) {
+    const { card, section } = createRemitoCardElements(group.title, group.description);
+    const grid = document.createElement('div');
+    const columnsClass = group.columns === 1 ? 'md:grid-cols-1' : 'md:grid-cols-2';
+    grid.className = `grid grid-cols-1 ${columnsClass} gap-x-6 gap-y-4`;
+
+    group.fields.forEach(field => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'input-group flex flex-col gap-1';
+        if (field.fullWidth) {
+            wrapper.classList.add('md:col-span-2');
+        }
+
+        const label = document.createElement('label');
+        label.className = 'font-semibold text-gray-700';
+        const labelText = field.label || field.key;
+        label.textContent = labelText;
+
+        const fieldId = `remito-${field.key}`;
+        label.setAttribute('for', fieldId);
+
+        const formatter = typeof field.formatter === 'function' ? field.formatter : formatDisplayValue;
+        const value = formatter(data[field.key], data);
+        const control = createReadOnlyControl(value, {
+            multiline: Boolean(field.multiline),
+            rows: field.rows,
+            id: fieldId,
+        });
+
+        wrapper.appendChild(label);
+        wrapper.appendChild(control);
+        grid.appendChild(wrapper);
+    });
+
+    section.appendChild(grid);
+    return card;
+}
+
+function renderRemitoParametersGroup(group, data) {
+    const { card, section } = createRemitoCardElements(group.title, group.description);
+    const table = document.createElement('table');
+    table.className = 'min-w-full divide-y divide-gray-200 border border-gray-200';
+
+    const thead = document.createElement('thead');
+    const headerRow = document.createElement('tr');
+    const headers = ['Parámetro', "Estado Inicial ('As Found')", "Estado Final ('As Left')"];
+    headers.forEach((headerText, index) => {
+        const th = document.createElement('th');
+        th.scope = 'col';
+        th.className = `px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 ${index === 0 ? '' : 'text-center'}`.trim();
+        th.textContent = headerText;
+        headerRow.appendChild(th);
+    });
+    thead.appendChild(headerRow);
+
+    const tbody = document.createElement('tbody');
+    tbody.className = 'divide-y divide-gray-200 bg-white';
+
+    const pairs = Array.isArray(group.pairs) && group.pairs.length ? group.pairs : REMITO_PARAMETER_PAIRS;
+
+    pairs.forEach(pair => {
+        const row = document.createElement('tr');
+        row.className = 'odd:bg-gray-50';
+
+        const labelCell = document.createElement('td');
+        labelCell.className = 'px-4 py-2 text-sm font-medium text-gray-700';
+        labelCell.textContent = pair.label;
+
+        const foundCell = document.createElement('td');
+        foundCell.className = 'px-4 py-2 text-center';
+        const foundValue = formatDisplayValue(data[pair.foundKey]);
+        foundCell.appendChild(createReadOnlyControl(foundValue, { id: `remito-${pair.foundKey}` }));
+
+        const leftCell = document.createElement('td');
+        leftCell.className = 'px-4 py-2 text-center';
+        const leftValue = formatDisplayValue(data[pair.leftKey]);
+        leftCell.appendChild(createReadOnlyControl(leftValue, { id: `remito-${pair.leftKey}` }));
+
+        row.append(labelCell, foundCell, leftCell);
+        tbody.appendChild(row);
+    });
+
+    table.append(thead, tbody);
+    section.appendChild(table);
+    return card;
+}
+
+function renderRemitoComponentsGroup(group, data) {
+    const { card, section } = createRemitoCardElements(group.title, group.description);
+    const table = document.createElement('table');
+    table.className = 'min-w-full divide-y divide-gray-200 border border-gray-200';
+
+    const thead = document.createElement('thead');
+    const headerRow = document.createElement('tr');
+    const headerLabels = ['Etapa', 'Detalle del Componente', 'Acción Realizada'];
+    headerLabels.forEach((label, index) => {
+        const th = document.createElement('th');
+        th.scope = 'col';
+        th.className = `px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-600 ${index === 0 ? '' : 'text-center'}`.trim();
+        th.textContent = label;
+        headerRow.appendChild(th);
+    });
+    thead.appendChild(headerRow);
+
+    const tbody = document.createElement('tbody');
+    tbody.className = 'divide-y divide-gray-200 bg-white';
+
+    const stages = Array.isArray(COMPONENT_STAGES) ? COMPONENT_STAGES : [];
+    stages.forEach(stage => {
+        const row = document.createElement('tr');
+        row.className = 'odd:bg-gray-50';
+
+        const stageCell = document.createElement('td');
+        stageCell.className = 'px-4 py-2 text-sm font-medium text-gray-700';
+        stageCell.textContent = stage.title || stage.id;
+
+        const detailsCell = document.createElement('td');
+        detailsCell.className = 'px-4 py-2';
+        const detailsKey = `${stage.id}_detalles`;
+        detailsCell.appendChild(createReadOnlyControl(data[detailsKey], { id: `remito-${detailsKey}` }));
+
+        const actionCell = document.createElement('td');
+        actionCell.className = 'px-4 py-2 text-center';
+        const actionKey = `${stage.id}_accion`;
+        actionCell.appendChild(createReadOnlyControl(data[actionKey], { id: `remito-${actionKey}` }));
+
+        row.append(stageCell, detailsCell, actionCell);
+        tbody.appendChild(row);
+    });
+
+    table.append(thead, tbody);
+    section.appendChild(table);
+    return card;
+}
+
+function getRemitoSectionsContainer() {
+    return document.getElementById('remito-sections');
+}
+
+function updateRemitoHeader(data) {
+    const reportNumberEl = document.getElementById('remito-report-number');
+    const reportDateEl = document.getElementById('remito-report-date');
+
+    if (reportNumberEl) {
+        reportNumberEl.textContent = formatDisplayValue(data?.numero_reporte) || '—';
+    }
+
+    if (reportDateEl) {
+        const formattedDate = formatDateValue(data?.fecha) || '—';
+        reportDateEl.textContent = formattedDate;
+    }
+}
+
+function populateRemitoView(data) {
+    const sectionsContainer = getRemitoSectionsContainer();
+    if (!sectionsContainer) {
+        return;
+    }
+
+    sectionsContainer.innerHTML = '';
+    updateRemitoHeader(data);
+
+    REMITO_FIELD_GROUPS.forEach(group => {
+        if (group.type === 'fields') {
+            sectionsContainer.appendChild(renderRemitoFieldsGroup(group, data));
+        } else if (group.type === 'pairs') {
+            sectionsContainer.appendChild(renderRemitoParametersGroup(group, data));
+        } else if (group.type === 'components') {
+            sectionsContainer.appendChild(renderRemitoComponentsGroup(group, data));
+        }
+    });
+}
+
+function showMaintenanceView() {
+    const maintenanceView = document.getElementById('maintenance-view');
+    const remitoView = document.getElementById('remito-view');
+
+    if (maintenanceView) {
+        maintenanceView.classList.remove('hidden');
+    }
+
+    if (remitoView) {
+        remitoView.classList.add('hidden');
+    }
+}
+
+function showRemitoView() {
+    if (!lastSavedReport) {
+        alert('Para generar el remito primero debes guardar el mantenimiento.');
+        return;
+    }
+
+    populateRemitoView(lastSavedReport);
+
+    const maintenanceView = document.getElementById('maintenance-view');
+    const remitoView = document.getElementById('remito-view');
+
+    if (maintenanceView) {
+        maintenanceView.classList.add('hidden');
+    }
+
+    if (remitoView) {
+        remitoView.classList.remove('hidden');
+    }
+
+    window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
 function showAppVersion() {
@@ -46,7 +419,9 @@ function showTab(tabName) {
         tabButton.classList.add('active');
     }
 
-    if (tabName === 'dashboard') {
+    if (tabName === 'nuevo') {
+        showMaintenanceView();
+    } else if (tabName === 'dashboard') {
         loadDashboard();
     }
 }
@@ -69,6 +444,7 @@ async function handleGuardarClick() {
         }
 
         await guardarMantenimiento(datos);
+        lastSavedReport = cloneReportData(datos);
         alert('✅ Mantenimiento guardado correctamente en el sistema');
 
         setReportNumber(reportNumber);
@@ -89,6 +465,22 @@ async function handleGuardarClick() {
     } finally {
         guardarBtn.textContent = originalText;
         guardarBtn.disabled = false;
+    }
+}
+
+function handleGenerarRemitoClick() {
+    showRemitoView();
+}
+
+function handleVolverFormularioClick() {
+    showMaintenanceView();
+}
+
+function handleImprimirRemitoClick() {
+    try {
+        window.print();
+    } catch (error) {
+        console.error('Error al imprimir el remito:', error);
     }
 }
 
@@ -185,6 +577,30 @@ function attachEventListeners() {
     const resetBtn = document.getElementById('resetButton');
     if (resetBtn) {
         resetBtn.addEventListener('click', resetForm);
+    }
+
+    const generarRemitoBtn = document.getElementById('generarRemitoButton');
+    if (generarRemitoBtn) {
+        generarRemitoBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            handleGenerarRemitoClick();
+        });
+    }
+
+    const volverFormularioBtn = document.getElementById('volverFormularioButton');
+    if (volverFormularioBtn) {
+        volverFormularioBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            handleVolverFormularioClick();
+        });
+    }
+
+    const imprimirRemitoBtn = document.getElementById('imprimirRemitoButton');
+    if (imprimirRemitoBtn) {
+        imprimirRemitoBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            handleImprimirRemitoClick();
+        });
     }
 
     const buscarBtn = document.getElementById('buscar-btn');


### PR DESCRIPTION
## Summary
- add the remito layout, actions, and container next to the maintenance form
- render the remito sections from the last saved report data and toggle between views
- hook the new buttons into the main event wiring and update the main test mocks

## Testing
- npm run build:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4379de34c83269b7432b7eefdcf56