### PR TITLE
Add remito finalization flow

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -562,6 +562,9 @@
                 <section class="border border-gray-200 rounded-lg p-6">
                     <label for="remito-observaciones" class="block text-lg font-semibold text-gray-800">Observaciones</label>
                     <textarea id="remito-observaciones" class="mt-4 w-full border border-gray-300 rounded-lg p-4 text-gray-700 min-h-[180px]" placeholder="Detalle las tareas realizadas y cualquier observación relevante..."></textarea>
+                    <div class="mt-6 flex justify-end">
+                        <button type="button" id="finalizarRemitoButton" class="action-button print-btn">Finalizar y Generar Remito</button>
+                    </div>
                 </section>
             </div>
         </div>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -122,3 +122,11 @@ export async function obtenerClientes({ forceRefresh = false } = {}) {
 
     return state.clientes;
 }
+
+export async function crearRemito({ reporte, observaciones } = {}) {
+    return postJSON({
+        action: 'crear_remito',
+        reporte,
+        observaciones,
+    });
+}


### PR DESCRIPTION
## Summary
- add the "Finalizar y Generar Remito" button to the remito view and hook it into the UI
- allow updating remito observations, call the backend to crear_remito, and refresh the displayed number with the response
- expose a crearRemito API helper and extend the remito tests to cover the new flow

## Testing
- npm test -- --runTestsByPath frontend/js/__tests__/main.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d43fe21da48326af7d3107edd909d3