### PR TITLE
Ajusta el estado inicial del botón Generar Remito

### DIFF
--- a/frontend/css/styles.build.css
+++ b/frontend/css/styles.build.css
@@ -612,70 +612,6 @@ video {
   }
 }
 
-
-.user-menu-toggle {
-  display: flex;
-  height: 2.5rem;
-  width: 2.5rem;
-  align-items: center;
-  justify-content: center;
-  border-radius: 9999px;
-  border-width: 1px;
-  --tw-border-opacity: 1;
-  border-color: rgb(226 232 240 / var(--tw-border-opacity, 1));
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
-  --tw-text-opacity: 1;
-  color: rgb(100 116 139 / var(--tw-text-opacity, 1));
-  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
-  transition-property: box-shadow;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 200ms;
-  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-}
-
-.user-menu-toggle:hover {
-  --tw-text-opacity: 1;
-  color: rgb(51 65 85 / var(--tw-text-opacity, 1));
-  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
-.user-menu-toggle:focus-visible {
-  outline: 2px solid transparent;
-  outline-offset: 2px;
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-  --tw-ring-opacity: 1;
-
-  --tw-ring-color: rgb(248 113 113 / var(--tw-ring-opacity, 1));
-  --tw-ring-offset-width: 2px;
-}
-
-.session-info__logout-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-.session-info__logout-button:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(220 38 38 / var(--tw-bg-opacity, 1));
-}
-
-.session-info__logout-button:focus-visible {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(252 165 165 / var(--tw-ring-opacity, 1));
-}
-
-.app-container {
-  min-height: 100vh;
-}
-
 .login-container {
   display: flex;
   min-height: 100vh;
@@ -758,50 +694,10 @@ video {
   border-width: 1px;
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
-
-  --tw-ring-color: rgb(59 130 246 / var(--tw-ring-opacity, 1));
-  --tw-ring-offset-width: 2px;
-}
-
-.user-menu {
-  position: absolute;
-  right: 0px;
-  top: 100%;
-  z-index: 30;
-  margin-top: 0.75rem;
-  width: 14rem;
-  overflow: hidden;
-  border-radius: 1rem;
-  border-width: 1px;
-  --tw-border-opacity: 1;
-  border-color: rgb(241 245 249 / var(--tw-border-opacity, 1));
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
-  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  max-width: min(18rem, calc(100vw - 1.5rem));
-}
-
-.user-menu__content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.5rem;
-}
-
-.user-menu__item {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  gap: 0.75rem;
-  border-radius: 0.75rem;
-
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
-
   font-size: 1rem;
   line-height: 1.5rem;
   --tw-text-opacity: 1;
@@ -828,12 +724,10 @@ video {
 }
 
 .login-error {
-
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
   --tw-text-opacity: 1;
-
   color: rgb(220 38 38 / var(--tw-text-opacity, 1));
 }
 
@@ -914,29 +808,12 @@ video {
 }
 
 .tab-button:focus-visible {
-
-  color: rgb(71 85 105 / var(--tw-text-opacity, 1));
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-}
-
-.user-menu__item:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(241 245 249 / var(--tw-bg-opacity, 1));
-  --tw-text-opacity: 1;
-  color: rgb(15 23 42 / var(--tw-text-opacity, 1));
-}
-
-.user-menu__item:focus-visible {
-
   outline: 2px solid transparent;
   outline-offset: 2px;
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
   --tw-ring-opacity: 1;
-
   --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity, 1));
   --tw-ring-offset-width: 2px;
 }
@@ -1044,6 +921,33 @@ video {
   --tw-ring-color: rgb(59 130 246 / var(--tw-ring-opacity, 1));
 }
 
+.action-button.print-btn:disabled {
+  cursor: not-allowed;
+  --tw-bg-opacity: 1;
+  background-color: rgb(156 163 175 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(243 244 246 / var(--tw-text-opacity, 1));
+  opacity: 0.8;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.action-button.print-btn:disabled:hover,
+    .action-button.print-btn:disabled:focus-visible {
+  cursor: not-allowed;
+  --tw-bg-opacity: 1;
+  background-color: rgb(156 163 175 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(243 244 246 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
 .client-detail-empty {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
@@ -1086,187 +990,6 @@ video {
   margin-top: 1.5rem;
 }
 
-.toggle-switch {
-  position: relative;
-  display: inline-flex;
-  height: 1.5rem;
-  width: 2.75rem;
-  flex-shrink: 0;
-  cursor: pointer;
-  align-items: center;
-}
-
-.toggle-switch-input {
-
-  --tw-ring-color: rgb(59 130 246 / var(--tw-ring-opacity, 1));
-  --tw-ring-offset-width: 2px;
-}
-
-.user-menu__item:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-.user-menu__logout {
-  --tw-text-opacity: 1;
-  color: rgb(220 38 38 / var(--tw-text-opacity, 1));
-}
-
-.user-menu__logout:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 242 242 / var(--tw-bg-opacity, 1));
-  --tw-text-opacity: 1;
-  color: rgb(185 28 28 / var(--tw-text-opacity, 1));
-}
-
-.user-menu__logout:focus-visible {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(239 68 68 / var(--tw-ring-opacity, 1));
-}
-
-.form-card > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-y-reverse: 0;
-  margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(1rem * var(--tw-space-y-reverse));
-}
-
-.form-card {
-  border-radius: 0.75rem;
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
-  padding: 1.5rem;
-  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
-.status-pass {
-  background-color: rgb(220 252 231);
-  color: rgb(22 101 52);
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.status-fail {
-  background-color: rgb(254 226 226);
-  color: rgb(153 27 27);
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.status-na {
-  background-color: rgb(229 231 235);
-  color: rgb(55 65 81);
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.component-toggle {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  align-items: stretch;
-  width: 100%;
-  border-radius: 9999px;
-  overflow: hidden;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: rgb(75 85 99);
-}
-
-.component-toggle__track {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background-color: rgb(229 231 235);
-  transition: background-color 0.2s ease;
-  z-index: 1;
-}
-
-.component-toggle__thumb {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 50%;
-  border-radius: inherit;
-  background-color: #ffffff;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
-  transition: transform 0.25s ease;
-  z-index: 2;
-}
-
-.component-toggle[data-state="cambiado"] .component-toggle__thumb {
-  transform: translateX(0%);
-}
-
-.component-toggle[data-state="inspeccionado"] .component-toggle__thumb {
-  transform: translateX(100%);
-}
-
-.component-toggle__input {
-
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-
-  white-space: nowrap;
-  border-width: 0;
-}
-
-.toggle-switch-slider {
-  position: relative;
-  display: inline-block;
-  height: 100%;
-  width: 100%;
-  border-radius: 9999px;
-  --tw-bg-opacity: 1;
-  background-color: rgb(209 213 219 / var(--tw-bg-opacity, 1));
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
-  transition-duration: 200ms;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.toggle-switch-slider::after {
-  content: '';
-  position: absolute;
-  top: 0.125rem;
-  left: 0.125rem;
-  width: 1.25rem;
-  height: 1.25rem;
-  border-radius: 9999px;
-  background-color: #fff;
-  box-shadow: 0 2px 4px rgb(15 23 42 / 0.2);
-  transition: transform 0.2s ease-in-out;
-}
-
-.toggle-switch-input:checked + .toggle-switch-slider {
-  --tw-bg-opacity: 1;
-  background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
-}
-
-.toggle-switch-input:checked + .toggle-switch-slider::after {
-  transform: translateX(1.25rem);
-}
-
-.toggle-switch-input:focus-visible + .toggle-switch-slider {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity, 1));
-  --tw-ring-offset-width: 2px;
-}
-
-.stage-action-status {
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  font-weight: 500;
-  --tw-text-opacity: 1;
-  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
-}
-
 .sanitizacion-toggle {
   display: inline-flex;
   width: 100%;
@@ -1284,91 +1007,11 @@ video {
 }
 
 .sanitizacion-toggle-option {
-
-  clip-path: inset(50%);
-  border: 0;
-  white-space: nowrap;
-}
-
-.component-toggle__option {
-  position: relative;
-  z-index: 5;
-  cursor: pointer;
-  padding: 0.75rem 0.5rem;
-  text-align: center;
-  color: rgb(107 114 128);
-  transition: color 0.2s ease, font-weight 0.2s ease;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.component-toggle__option:hover {
-  color: rgb(55 65 81);
-}
-
-.component-toggle[data-state="cambiado"] .component-toggle__option--cambiado,
-    .component-toggle[data-state="inspeccionado"] .component-toggle__option--inspeccionado {
-  color: rgb(17 24 39);
-  font-weight: 600;
-}
-
-.sanitizacion-options {
-  --sanitizacion-border: rgb(209 213 219);
-  --sanitizacion-background: rgb(249 250 251);
-  --sanitizacion-active-bg: rgb(229 231 235);
-  --sanitizacion-active-color: rgb(55 65 81);
-  --sanitizacion-active-border: rgba(107, 114, 128, 0.35);
-  --sanitizacion-active-shadow: rgba(55, 65, 81, 0.15);
-  display: flex;
-  width: 100%;
-  border-radius: 9999px;
-  border: 1px solid var(--sanitizacion-border);
-  background-color: var(--sanitizacion-background);
-  overflow: hidden;
-  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
-  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.sanitizacion-options[data-status="success"] {
-  --sanitizacion-border: rgb(134 239 172);
-  --sanitizacion-background: rgb(240 253 244);
-  --sanitizacion-active-bg: rgb(220 252 231);
-  --sanitizacion-active-color: rgb(22 101 52);
-  --sanitizacion-active-border: rgba(34, 197, 94, 0.45);
-  --sanitizacion-active-shadow: rgba(22, 101, 52, 0.25);
-}
-
-.sanitizacion-options[data-status="danger"] {
-  --sanitizacion-border: rgb(252 165 165);
-  --sanitizacion-background: rgb(254 242 242);
-  --sanitizacion-active-bg: rgb(254 226 226);
-  --sanitizacion-active-color: rgb(153 27 27);
-  --sanitizacion-active-border: rgba(248, 113, 113, 0.45);
-  --sanitizacion-active-shadow: rgba(153, 27, 27, 0.25);
-}
-
-.sanitizacion-options[data-status="neutral"] {
-  --sanitizacion-border: rgb(209 213 219);
-  --sanitizacion-background: rgb(249 250 251);
-  --sanitizacion-active-bg: rgb(229 231 235);
-  --sanitizacion-active-color: rgb(55 65 81);
-  --sanitizacion-active-border: rgba(107, 114, 128, 0.35);
-  --sanitizacion-active-shadow: rgba(55, 65, 81, 0.15);
-}
-
-.sanitizacion-option {
-
   position: relative;
   flex: 1 1 0%;
 }
 
-
-.sanitizacion-option input {
-
+.sanitizacion-toggle-option input {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -1376,41 +1019,115 @@ video {
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
-
-  clip-path: inset(50%);
   white-space: nowrap;
-  border: 0;
+  border-width: 0;
 }
 
-.sanitizacion-option span {
+.sanitizacion-toggle-option span {
   display: block;
   width: 100%;
-  padding: 0.6rem 0.75rem;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-color: transparent;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
   text-align: center;
   font-size: 0.875rem;
-  font-weight: 500;
-  color: rgb(75 85 99);
-  border-left: 1px solid rgba(148, 163, 184, 0.25);
-  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-          user-select: none;
+  line-height: 1.25rem;
+  font-weight: 600;
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 }
 
-.sanitizacion-option:first-child span {
-  border-left-color: transparent;
+.sanitizacion-toggle-option input:not(:checked) + span {
+  background-color: transparent;
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
 }
 
-.sanitizacion-option input:not(:checked) + span:hover {
-  background-color: rgba(255, 255, 255, 0.6);
-  color: rgb(31 41 55);
+.sanitizacion-toggle-option input:not(:checked) + span:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
 }
 
-.sanitizacion-option input:checked + span {
-  color: var(--sanitizacion-active-color);
-  background-color: var(--sanitizacion-active-bg);
-  border-color: var(--sanitizacion-active-border);
-  box-shadow: inset 0 0 0 1px var(--sanitizacion-active-border), 0 6px 18px -10px var(--sanitizacion-active-shadow);
+.sanitizacion-toggle-option input:focus-visible + span {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(96 165 250 / var(--tw-ring-opacity, 1));
+  --tw-ring-offset-width: 1px;
+}
+
+.sanitizacion-toggle-option[data-option='N/A'] input:checked + span {
+  border-color: transparent;
+  --tw-bg-opacity: 1;
+  background-color: rgb(100 116 139 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.sanitizacion-toggle-option[data-option='Realizada'] input:checked + span {
+  border-color: transparent;
+  --tw-bg-opacity: 1;
+  background-color: rgb(16 185 129 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.sanitizacion-toggle-option[data-option='No Realizada'] input:checked + span {
+  border-color: transparent;
+  --tw-bg-opacity: 1;
+  background-color: rgb(244 63 94 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.status-pass {
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(110 231 183 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(209 250 229 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(4 120 87 / var(--tw-text-opacity, 1));
+}
+
+.status-fail {
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(253 164 175 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 228 230 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(190 18 60 / var(--tw-text-opacity, 1));
+}
+
+.status-na {
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(203 213 225 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(241 245 249 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(51 65 85 / var(--tw-text-opacity, 1));
 }
 
 .sr-only {
@@ -1423,7 +1140,6 @@ video {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border-width: 0;
-
 }
 
 .fixed {
@@ -1442,11 +1158,6 @@ video {
   z-index: 40;
 }
 
-
-.z-50 {
-  z-index: 50;
-}
-
 .order-1 {
   order: 1;
 }
@@ -1458,7 +1169,6 @@ video {
 .order-3 {
   order: 3;
 }
-
 
 .mx-auto {
   margin-left: auto;
@@ -1486,6 +1196,10 @@ video {
   margin-bottom: 1.5rem;
 }
 
+.mb-8 {
+  margin-bottom: 2rem;
+}
+
 .ml-2 {
   margin-left: 0.5rem;
 }
@@ -1494,15 +1208,21 @@ video {
   margin-left: auto;
 }
 
-
 .mr-2 {
   margin-right: 0.5rem;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
 }
 
 .mt-2 {
   margin-top: 0.5rem;
 }
 
+.mt-4 {
+  margin-top: 1rem;
+}
 
 .mt-6 {
   margin-top: 1.5rem;
@@ -1532,23 +1252,25 @@ video {
   display: none;
 }
 
-
 .h-14 {
   height: 3.5rem;
+}
+
+.h-16 {
+  height: 4rem;
 }
 
 .h-5 {
   height: 1.25rem;
 }
 
-
 .max-h-screen {
   max-height: 100vh;
 }
 
-
-.min-h-screen {
-  min-height: 100vh;
+.min-h-\[180px\] {
+  min-height: 180px;
+}
 
 .w-5 {
   width: 1.25rem;
@@ -1556,7 +1278,6 @@ video {
 
 .w-auto {
   width: auto;
-
 }
 
 .w-full {
@@ -1575,28 +1296,21 @@ video {
   max-width: 80rem;
 }
 
-
-.grid-cols-1 {
-  grid-template-columns: repeat(1, minmax(0, 1fr));
-
-.max-w-md {
-  max-width: 28rem;
-}
-
 .flex-shrink-0 {
   flex-shrink: 0;
-
 }
 
 .grid-cols-1 {
   grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 
+.flex-col {
+  flex-direction: column;
+}
 
 .flex-wrap {
   flex-wrap: wrap;
 }
-
 
 .items-end {
   align-items: flex-end;
@@ -1614,16 +1328,16 @@ video {
   justify-content: center;
 }
 
+.justify-between {
+  justify-content: space-between;
+}
+
 .gap-1 {
   gap: 0.25rem;
 }
 
 .gap-2 {
   gap: 0.5rem;
-}
-
-.gap-3 {
-  gap: 0.75rem;
 }
 
 .gap-3 {
@@ -1674,10 +1388,22 @@ video {
   margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.25rem * var(--tw-space-y-reverse));
+}
+
 .space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2rem * var(--tw-space-y-reverse));
 }
 
 .divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -1689,6 +1415,10 @@ video {
 .divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
   --tw-divide-opacity: 1;
   border-color: rgb(229 231 235 / var(--tw-divide-opacity, 1));
+}
+
+.overflow-hidden {
+  overflow: hidden;
 }
 
 .overflow-x-auto {
@@ -1721,6 +1451,10 @@ video {
 
 .border {
   border-width: 1px;
+}
+
+.border-b {
+  border-bottom-width: 1px;
 }
 
 .border-t {
@@ -1813,6 +1547,10 @@ video {
   padding-bottom: 1rem;
 }
 
+.pb-6 {
+  padding-bottom: 1.5rem;
+}
+
 .text-left {
   text-align: left;
 }
@@ -1821,9 +1559,23 @@ video {
   text-align: center;
 }
 
+.text-right {
+  text-align: right;
+}
+
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
 .text-3xl {
   font-size: 1.875rem;
   line-height: 2.25rem;
+}
+
+.text-base {
+  font-size: 1rem;
+  line-height: 1.5rem;
 }
 
 .text-lg {
@@ -1862,6 +1614,14 @@ video {
   text-transform: uppercase;
 }
 
+.tracking-wide {
+  letter-spacing: 0.025em;
+}
+
+.tracking-widest {
+  letter-spacing: 0.1em;
+}
+
 .text-blue-600 {
   --tw-text-opacity: 1;
   color: rgb(37 99 235 / var(--tw-text-opacity, 1));
@@ -1870,6 +1630,11 @@ video {
 .text-gray-500 {
   --tw-text-opacity: 1;
   color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+.text-gray-600 {
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
 }
 
 .text-gray-700 {
@@ -1928,6 +1693,11 @@ video {
   background-color: rgb(29 78 216 / var(--tw-bg-opacity, 1));
 }
 
+.hover\:bg-gray-50:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
+}
+
 .hover\:bg-gray-600:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(75 85 99 / var(--tw-bg-opacity, 1));
@@ -1972,6 +1742,10 @@ video {
     grid-column: span 3 / span 3;
   }
 
+  .sm\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .sm\:grid-cols-6 {
     grid-template-columns: repeat(6, minmax(0, 1fr));
   }
@@ -1981,26 +1755,6 @@ video {
   .md\:order-2 {
     order: 2;
   }
-
-
-  .md\:grid-cols-2 {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .md\:grid-cols-3 {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .md\:flex-row {
-    flex-direction: row;
-  }
-
-  .md\:items-center {
-    align-items: center;
-  }
-
-  .md\:justify-between {
-    justify-content: space-between;
 
   .md\:order-3 {
     order: 3;
@@ -2014,6 +1768,14 @@ video {
     height: 4rem;
   }
 
+  .md\:h-20 {
+    height: 5rem;
+  }
+
+  .md\:w-auto {
+    width: auto;
+  }
+
   .md\:flex-1 {
     flex: 1 1 0%;
   }
@@ -2024,11 +1786,34 @@ video {
 
   .md\:grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 
+  .md\:flex-row {
+    flex-direction: row;
+  }
+
+  .md\:items-start {
+    align-items: flex-start;
+  }
+
+  .md\:items-center {
+    align-items: center;
+  }
+
+  .md\:justify-between {
+    justify-content: space-between;
+  }
+
+  .md\:gap-6 {
+    gap: 1.5rem;
   }
 
   .md\:p-8 {
     padding: 2rem;
+  }
+
+  .md\:text-right {
+    text-align: right;
   }
 }
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -176,6 +176,15 @@
         @apply ring-blue-500;
     }
 
+    .action-button.print-btn:disabled {
+        @apply bg-gray-400 text-gray-100 cursor-not-allowed opacity-80 shadow-none;
+    }
+
+    .action-button.print-btn:disabled:hover,
+    .action-button.print-btn:disabled:focus-visible {
+        @apply bg-gray-400 text-gray-100 cursor-not-allowed ring-0 shadow-none;
+    }
+
     .client-detail-empty {
         @apply bg-gray-100 text-gray-600 placeholder-gray-400;
     }

--- a/frontend/js/__tests__/main.test.js
+++ b/frontend/js/__tests__/main.test.js
@@ -126,6 +126,7 @@ describe('handleGuardarClick', () => {
         const generarRemitoButton = document.getElementById('generarRemitoButton');
         expect(generarRemitoButton).not.toBeNull();
         expect(generarRemitoButton.disabled).toBe(true);
+        expect(generarRemitoButton.hasAttribute('disabled')).toBe(true);
 
         await handleGuardarClick();
 
@@ -137,6 +138,7 @@ describe('handleGuardarClick', () => {
         expect(setReportNumberMock).toHaveBeenCalledWith(REPORT_NUMBER);
 
         expect(generarRemitoButton.disabled).toBe(false);
+        expect(generarRemitoButton.hasAttribute('disabled')).toBe(false);
 
         const savedNumber = guardarMantenimientoMock.mock.calls[0][0].numero_reporte;
         const displayedNumber = setReportNumberMock.mock.calls[0][0];
@@ -230,6 +232,9 @@ describe('manejo de la vista de remito', () => {
         handleGenerarRemitoClick();
 
         expect(window.alert).toHaveBeenCalledTimes(1);
+        const generarRemitoButton = document.getElementById('generarRemitoButton');
+        expect(generarRemitoButton.disabled).toBe(true);
+        expect(generarRemitoButton.hasAttribute('disabled')).toBe(true);
         const formView = document.getElementById('tab-nuevo');
         const remitoView = document.getElementById('remito-servicio');
         expect(formView.classList.contains('hidden')).toBe(false);

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -255,8 +255,27 @@ function showRemitoView() {
     }
 }
 
+function setGenerarRemitoButtonEnabled(enabled) {
+    const generarRemitoBtn = document.getElementById('generarRemitoButton');
+    if (!generarRemitoBtn) {
+        return;
+    }
+
+    if (enabled) {
+        generarRemitoBtn.disabled = false;
+        generarRemitoBtn.removeAttribute('disabled');
+        return;
+    }
+
+    generarRemitoBtn.disabled = true;
+    if (!generarRemitoBtn.hasAttribute('disabled')) {
+        generarRemitoBtn.setAttribute('disabled', 'disabled');
+    }
+}
+
 function handleGenerarRemitoClick() {
     if (!lastSavedReportData) {
+        setGenerarRemitoButtonEnabled(false);
         alert('Primero debes guardar un mantenimiento para generar el remito.');
         return;
     }
@@ -378,7 +397,6 @@ function showTab(tabName) {
 
 async function handleGuardarClick() {
     const guardarBtn = document.getElementById('guardarButton');
-    const generarRemitoBtn = document.getElementById('generarRemitoButton');
     if (!guardarBtn) {
         return;
     }
@@ -398,9 +416,7 @@ async function handleGuardarClick() {
         lastSavedReportData = createReportSnapshot(datos);
         alert('✅ Mantenimiento guardado correctamente en el sistema');
 
-        if (generarRemitoBtn) {
-            generarRemitoBtn.disabled = false;
-        }
+        setGenerarRemitoButtonEnabled(true);
 
         setReportNumber(reportNumber);
 
@@ -598,6 +614,7 @@ async function initializeSystem() {
     configureClientSelect(clientes);
     initializeForm();
     attachEventListeners();
+    setGenerarRemitoButtonEnabled(false);
     showTab('nuevo');
 }
 


### PR DESCRIPTION
## Summary
- añade un helper para controlar el botón de remito y activarlo tras guardar el mantenimiento
- aplica estilos grises al botón cuando está deshabilitado para reflejar su estado inicial
- actualiza las pruebas y recompila los estilos de Tailwind

## Testing
- npm run build:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d52c130d008326b2b2d5b85568799d