### PR TITLE
Reconnect dashboard navigation with modular search/dashboard logic

### DIFF
--- a/frontend/js/__tests__/main.test.js
+++ b/frontend/js/__tests__/main.test.js
@@ -116,6 +116,11 @@ describe('handleGuardarClick', () => {
 
         jest.unstable_mockModule('../modules/dashboard/dashboard.js', () => ({
             renderDashboard: jest.fn(),
+            createDashboardModule: jest.fn(() => ({
+                initialize: jest.fn(),
+                show: jest.fn(),
+                refresh: jest.fn(),
+            })),
         }));
 
         const mainModule = await import('../main.js');
@@ -261,6 +266,11 @@ describe('manejo de la vista de remito', () => {
 
         jest.unstable_mockModule('../modules/dashboard/dashboard.js', () => ({
             renderDashboard: jest.fn(),
+            createDashboardModule: jest.fn(() => ({
+                initialize: jest.fn(),
+                show: jest.fn(),
+                refresh: jest.fn(),
+            })),
         }));
 
         const mainModule = await import('../main.js');

--- a/frontend/js/modules/busqueda/busqueda.js
+++ b/frontend/js/modules/busqueda/busqueda.js
@@ -10,8 +10,9 @@ function getElement(id) {
     return document.getElementById(id);
 }
 
-export function createSearchModule(api) {
+export function createSearchModule(api, dependencies = {}) {
     const { buscarMantenimientos, actualizarMantenimiento, eliminarMantenimiento } = api;
+    const { showView: showViewFn } = dependencies;
 
     let eventsInitialized = false;
 
@@ -126,8 +127,15 @@ export function createSearchModule(api) {
         eventsInitialized = true;
     }
 
+    function show() {
+        if (typeof showViewFn === 'function') {
+            showViewFn('tab-buscar');
+        }
+    }
+
     return {
         initialize,
+        show,
         handleBuscarClick,
         handleLimpiarBusqueda,
         handleEditarMantenimiento,

--- a/frontend/js/modules/dashboard/dashboard.js
+++ b/frontend/js/modules/dashboard/dashboard.js
@@ -137,3 +137,34 @@ export function renderDashboard(data) {
     createTechnicianChart(Array.isArray(data.tecnicosData) ? data.tecnicosData : []);
     renderUpcomingMaintenances(Array.isArray(data.proximosMantenimientos) ? data.proximosMantenimientos : []);
 }
+
+export function createDashboardModule(api, dependencies = {}) {
+    const { obtenerDashboard } = api;
+    const { showView: showViewFn } = dependencies;
+
+    async function fetchAndRender() {
+        try {
+            const data = await obtenerDashboard();
+            renderDashboard(data);
+        } catch (error) {
+            console.error('Error cargando dashboard:', error);
+        }
+    }
+
+    async function show() {
+        if (typeof showViewFn === 'function') {
+            showViewFn('tab-dashboard');
+        }
+        await fetchAndRender();
+    }
+
+    async function initialize() {
+        await fetchAndRender();
+    }
+
+    return {
+        initialize,
+        show,
+        refresh: fetchAndRender,
+    };
+}


### PR DESCRIPTION
## Summary
- wire main navigation to the modularized search and dashboard controllers, passing the shared view manager
- add a dashboard module factory that fetches API data and shows the dashboard view on demand
- expose a search-module `show` helper and update unit mocks to cover the new dashboard module export

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5552c86f08326b3aa4e23e7114766