### PR TITLE
Fix remito view visibility

### DIFF
--- a/frontend/css/styles.build.css
+++ b/frontend/css/styles.build.css
@@ -1212,10 +1212,6 @@ video {
   margin-right: 0.5rem;
 }
 
-.mt-1 {
-  margin-top: 0.25rem;
-}
-
 .mt-2 {
   margin-top: 0.5rem;
 }
@@ -1256,10 +1252,6 @@ video {
   height: 3.5rem;
 }
 
-.h-16 {
-  height: 4rem;
-}
-
 .h-5 {
   height: 1.25rem;
 }
@@ -1268,8 +1260,8 @@ video {
   max-height: 100vh;
 }
 
-.min-h-\[180px\] {
-  min-height: 180px;
+.min-h-\[160px\] {
+  min-height: 160px;
 }
 
 .w-5 {
@@ -1290,6 +1282,10 @@ video {
 
 .max-w-4xl {
   max-width: 56rem;
+}
+
+.max-w-5xl {
+  max-width: 64rem;
 }
 
 .max-w-7xl {
@@ -1388,12 +1384,6 @@ video {
   margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
-.space-y-1 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-y-reverse: 0;
-  margin-top: calc(0.25rem * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(0.25rem * var(--tw-space-y-reverse));
-}
-
 .space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
@@ -1417,10 +1407,6 @@ video {
   border-color: rgb(229 231 235 / var(--tw-divide-opacity, 1));
 }
 
-.overflow-hidden {
-  overflow: hidden;
-}
-
 .overflow-x-auto {
   overflow-x: auto;
 }
@@ -1437,6 +1423,14 @@ video {
   border-radius: 0.25rem;
 }
 
+.rounded-2xl {
+  border-radius: 1rem;
+}
+
+.rounded-3xl {
+  border-radius: 1.5rem;
+}
+
 .rounded-lg {
   border-radius: 0.5rem;
 }
@@ -1451,10 +1445,6 @@ video {
 
 .border {
   border-width: 1px;
-}
-
-.border-b {
-  border-bottom-width: 1px;
 }
 
 .border-t {
@@ -1517,6 +1507,10 @@ video {
   padding: 1.5rem;
 }
 
+.p-8 {
+  padding: 2rem;
+}
+
 .px-3 {
   padding-left: 0.75rem;
   padding-right: 0.75rem;
@@ -1547,10 +1541,6 @@ video {
   padding-bottom: 1rem;
 }
 
-.pb-6 {
-  padding-bottom: 1.5rem;
-}
-
 .text-left {
   text-align: left;
 }
@@ -1571,11 +1561,6 @@ video {
 .text-3xl {
   font-size: 1.875rem;
   line-height: 2.25rem;
-}
-
-.text-base {
-  font-size: 1rem;
-  line-height: 1.5rem;
 }
 
 .text-lg {
@@ -1614,12 +1599,8 @@ video {
   text-transform: uppercase;
 }
 
-.tracking-wide {
-  letter-spacing: 0.025em;
-}
-
-.tracking-widest {
-  letter-spacing: 0.1em;
+.tracking-wider {
+  letter-spacing: 0.05em;
 }
 
 .text-blue-600 {
@@ -1670,6 +1651,12 @@ video {
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+.shadow-lg {
+  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .shadow-sm {
@@ -1742,10 +1729,6 @@ video {
     grid-column: span 3 / span 3;
   }
 
-  .sm\:grid-cols-2 {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
   .sm\:grid-cols-6 {
     grid-template-columns: repeat(6, minmax(0, 1fr));
   }
@@ -1768,14 +1751,6 @@ video {
     height: 4rem;
   }
 
-  .md\:h-20 {
-    height: 5rem;
-  }
-
-  .md\:w-auto {
-    width: auto;
-  }
-
   .md\:flex-1 {
     flex: 1 1 0%;
   }
@@ -1792,10 +1767,6 @@ video {
     flex-direction: row;
   }
 
-  .md\:items-start {
-    align-items: flex-start;
-  }
-
   .md\:items-center {
     align-items: center;
   }
@@ -1804,16 +1775,8 @@ video {
     justify-content: space-between;
   }
 
-  .md\:gap-6 {
-    gap: 1.5rem;
-  }
-
   .md\:p-8 {
     padding: 2rem;
-  }
-
-  .md\:text-right {
-    text-align: right;
   }
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0"></script>
 </head>
 <body class="bg-gray-100">
-    <div class="container mx-auto p-4 md:p-8 max-w-7xl">
+    <div id="main-view" class="container mx-auto p-4 md:p-8 max-w-7xl">
         <header class="relative flex flex-wrap items-center justify-between gap-4 mb-8 no-print">
             <div class="order-1 flex-shrink-0">
                 <img src="/OHM-agua.png" alt="Logo OHM Agua" class="h-14 w-auto md:h-16">
@@ -57,8 +57,9 @@
             <button class="tab-button" id="tab-dashboard-btn">Dashboard</button>
         </div>
 
+        <div class="space-y-8" id="main-content">
         <!-- Pestaña: Nuevo Mantenimiento -->
-        <div id="tab-nuevo" class="tab-content">
+        <section id="tab-nuevo" class="tab-content">
             <form id="maintenance-form">
                 <!-- Sección A: Datos del Servicio y del Equipo -->
 
@@ -342,10 +343,10 @@
                     <button type="button" id="generar-remito-btn" class="action-button print-btn" disabled>Generar Remito</button>
                 </div>
             </form>
-        </div>
+        </section><!-- /tab-nuevo -->
 
         <!-- Pestaña: Buscar/Editar -->
-        <div id="tab-buscar" class="tab-content hidden">
+        <section id="tab-buscar" class="tab-content hidden">
             <div class="form-section">
                 <h2>Buscar Mantenimientos</h2>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
@@ -405,10 +406,10 @@
                     </div>
                 </div>
             </div>
-        </div>
+        </section>
 
         <!-- Pestaña: Dashboard -->
-        <div id="tab-dashboard" class="tab-content hidden">
+        <section id="tab-dashboard" class="tab-content hidden">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
                 <div class="dashboard-card">
                     <h3 class="text-lg font-semibold mb-2">Total Mantenimientos</h3>
@@ -457,9 +458,9 @@
                     </table>
                 </div>
             </div>
-        </div>
+        </section>
 
-        <div id="remito-view" class="hidden">
+        <section id="remito-view" class="tab-content hidden">
             <div class="max-w-5xl mx-auto">
                 <div class="bg-white shadow-lg rounded-3xl p-8 mb-8 border border-gray-200">
                     <h2 class="text-2xl font-bold text-gray-800">Generación de Remito</h2>
@@ -570,7 +571,7 @@
                     </div>
                 </form>
             </div>
-        </div>
+        </section>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- wrap the main application container with an id so the login module can toggle it reliably and keep tab content grouped in a dedicated wrapper
- move the remito markup out of the maintenance form by turning each view into its own section so the Remito screen shows up when requested
- rebuild the compiled Tailwind stylesheet to include the utilities used by the new layout spacing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1fd662ad48326a426ca27389f9d88