### PR TITLE
Add auto-fill helper for maintenance form

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -338,6 +338,7 @@
 
                 <!-- Botones de Acción -->
                 <div class="flex justify-end space-x-4 mt-8 no-print">
+                    <button type="button" id="autoFillButton" class="action-button reset-btn">Auto Rellenar</button>
                     <button type="button" id="resetButton" class="action-button reset-btn">Limpiar Formulario</button>
                     <button type="button" id="guardarButton" class="action-button print-btn">Guardar y Generar Reporte</button>
                     <button type="button" id="generar-remito-btn" class="action-button print-btn" disabled>Generar Remito</button>

--- a/frontend/js/__tests__/main.test.js
+++ b/frontend/js/__tests__/main.test.js
@@ -74,6 +74,7 @@ describe('manejo del guardado de mantenimientos', () => {
         }));
 
         jest.unstable_mockModule('../modules/mantenimiento/forms.js', () => ({
+            autoFillForm: jest.fn(),
             configureClientSelect: jest.fn(),
             generateReportNumber: generateReportNumberMock,
             getFormData: getFormDataMock,
@@ -175,6 +176,7 @@ describe('flujo de generación y finalización de remito', () => {
         }));
 
         jest.unstable_mockModule('../modules/mantenimiento/forms.js', () => ({
+            autoFillForm: jest.fn(),
             configureClientSelect: jest.fn(),
             generateReportNumber: jest.fn(),
             getFormData: jest.fn(),

--- a/frontend/js/modules/mantenimiento/maintenance.js
+++ b/frontend/js/modules/mantenimiento/maintenance.js
@@ -1,4 +1,5 @@
 import {
+    autoFillForm,
     configureClientSelect,
     generateReportNumber,
     getFormData,
@@ -51,6 +52,14 @@ export function createMaintenanceModule(api, callbacks = {}) {
             });
         }
 
+        const autoFillBtn = getElement('autoFillButton');
+        if (autoFillBtn) {
+            autoFillBtn.addEventListener('click', event => {
+                event.preventDefault();
+                handleAutoFillClick();
+            });
+        }
+
         eventsInitialized = true;
     }
 
@@ -78,6 +87,10 @@ export function createMaintenanceModule(api, callbacks = {}) {
     function handleResetClick() {
         resetForm();
         notifyReportReset();
+    }
+
+    function handleAutoFillClick() {
+        autoFillForm();
     }
 
     async function handleGuardarClick() {


### PR DESCRIPTION
## Summary
- add an "Auto Rellenar" button to the mantenimiento form for quick data entry during testing
- implement an autoFillForm helper that populates operational fields, component toggles, sanitization, and summary text
- update maintenance module wiring and unit tests to support the new helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e30ae8de148326b81394e2f825cfc2