### PR TITLE
Fix remito headers access in Apps Script repository

### DIFF
--- a/scripts/RemitoRepository2025.txt
+++ b/scripts/RemitoRepository2025.txt
@@ -9,6 +9,7 @@ const REMITOS_HEADERS = [
 ];
 
 const RemitoRepository = {
+  REMITOS_HEADERS,
   /**
    * Obtiene la hoja de Remitos. Si no existe, la crea con los encabezados.
    */
@@ -17,7 +18,7 @@ const RemitoRepository = {
     let sheet = ss.getSheetByName(REMITOS_SHEET_NAME);
     if (!sheet) {
       sheet = ss.insertSheet(REMITOS_SHEET_NAME);
-      sheet.appendRow(REMITOS_HEADERS);
+      sheet.appendRow(this.REMITOS_HEADERS);
       // Inmovilizar la primera fila (encabezados)
       sheet.setFrozenRows(1);
     }
@@ -47,5 +48,13 @@ const RemitoRepository = {
   guardar(remitoRowData) {
     const sheet = this.getSheet_();
     sheet.appendRow(remitoRowData);
+  },
+
+  /**
+   * Devuelve los encabezados configurados para la hoja de remitos.
+   * @returns {string[]} Lista de encabezados.
+   */
+  getHeaders() {
+    return this.REMITOS_HEADERS;
   }
 };

--- a/scripts/RemitoService 2025.txt
+++ b/scripts/RemitoService 2025.txt
@@ -79,7 +79,7 @@ const RemitoService = {
   obtenerRemitos(page = 1, pageSize = 20) {
     const sheet = RemitoRepository.getSheet_();
     const lastRow = sheet.getLastRow();
-    const headers = RemitoRepository.REMITOS_HEADERS; // Importante: Asegurarse de que REMITOS_HEADERS es accesible aquí
+    const headers = RemitoRepository.getHeaders();
 
     // Si solo hay encabezados o no hay datos, devolver un objeto vacío
     if (lastRow < 2) { 


### PR DESCRIPTION
## Summary
- expose the remitos headers array through RemitoRepository so other services can reuse it
- update RemitoService to consume the new accessor when mapping rows into objects

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5c1c49f308326aa0e401f9dea3317