### PR TITLE
Map remito client fields for display

### DIFF
--- a/frontend/js/modules/remitos-gestion/remitos-gestion.js
+++ b/frontend/js/modules/remitos-gestion/remitos-gestion.js
@@ -2,6 +2,25 @@ import { obtenerRemitos } from '../../api.js';
 
 const DEFAULT_PAGE_SIZE = 20;
 
+function pickValue(source, keys) {
+    if (!source || typeof source !== 'object' || !Array.isArray(keys)) {
+        return undefined;
+    }
+
+    for (const key of keys) {
+        if (!key || typeof key !== 'string') {
+            continue;
+        }
+
+        const value = source[key];
+        if (value !== undefined && value !== null && value !== '') {
+            return value;
+        }
+    }
+
+    return undefined;
+}
+
 function sanitizeString(value) {
     if (value === null || value === undefined) {
         return '';
@@ -122,20 +141,36 @@ function normalizeRemitoForDisplay(remito) {
     const fechaRemitoISO = remito.fechaRemitoISO ?? remito.FechaRemitoISO;
     const fechaServicioISO = remito.fechaServicioISO ?? remito.FechaServicioISO;
 
+    const numeroRemitoValue = pickValue(remito, ['numeroRemito', 'NumeroRemito']);
+    const numeroReporteValue = pickValue(remito, ['numeroReporte', 'NumeroReporte']);
+    const clienteValue = pickValue(remito, ['cliente', 'Cliente', 'NombreCliente']);
+    const fechaRemitoValue = pickValue(remito, ['fechaRemito', 'FechaRemito', 'FechaCreacion']);
+    const fechaRemitoIsoValue = pickValue(remito, ['fechaRemitoISO', 'FechaRemitoISO', 'FechaCreacionISO']);
+    const fechaServicioValue = pickValue(remito, ['fechaServicio', 'FechaServicio']);
+    const tecnicoValue = pickValue(remito, ['tecnico', 'Tecnico', 'MailTecnico']);
+    const observacionesValue = pickValue(remito, ['observaciones', 'Observaciones']);
+    const direccionValue = pickValue(remito, ['direccion', 'Direccion']);
+    const telefonoValue = pickValue(remito, ['telefono', 'Telefono']);
+    const emailValue = pickValue(remito, ['email', 'Email', 'MailCliente']);
+    const reporteIdValue = pickValue(remito, ['reporteId', 'ReporteID', 'IdUnico', 'IDInterna']);
+
     return {
-        numeroRemito: sanitizeString(remito.numeroRemito ?? remito.NumeroRemito),
-        numeroReporte: sanitizeString(remito.numeroReporte ?? remito.NumeroReporte),
-        cliente: sanitizeString(remito.cliente ?? remito.Cliente),
-        fechaRemito: formatDateValue(remito.fechaRemito ?? remito.FechaRemito, fechaRemitoISO),
-        fechaRemitoISO: sanitizeString(fechaRemitoISO),
-        fechaServicio: formatDateValue(remito.fechaServicio ?? remito.FechaServicio, fechaServicioISO),
+        numeroRemito: sanitizeString(numeroRemitoValue),
+        numeroReporte: sanitizeString(numeroReporteValue),
+        cliente: sanitizeString(clienteValue),
+        fechaRemito: formatDateValue(
+            fechaRemitoValue,
+            fechaRemitoIsoValue ?? fechaRemitoISO
+        ),
+        fechaRemitoISO: sanitizeString(fechaRemitoIsoValue ?? fechaRemitoISO),
+        fechaServicio: formatDateValue(fechaServicioValue, fechaServicioISO),
         fechaServicioISO: sanitizeString(fechaServicioISO),
-        tecnico: sanitizeString(remito.tecnico ?? remito.Tecnico),
-        observaciones: sanitizeString(remito.observaciones ?? remito.Observaciones),
-        direccion: sanitizeString(remito.direccion ?? remito.Direccion),
-        telefono: sanitizeString(remito.telefono ?? remito.Telefono),
-        email: sanitizeString(remito.email ?? remito.Email),
-        reporteId: sanitizeString(remito.reporteId ?? remito.ReporteID),
+        tecnico: sanitizeString(tecnicoValue),
+        observaciones: sanitizeString(observacionesValue),
+        direccion: sanitizeString(direccionValue),
+        telefono: sanitizeString(telefonoValue),
+        email: sanitizeString(emailValue),
+        reporteId: sanitizeString(reporteIdValue),
     };
 }
 

--- a/frontend/js/modules/remitos-gestion/remitos-gestion.test.js
+++ b/frontend/js/modules/remitos-gestion/remitos-gestion.test.js
@@ -1,0 +1,33 @@
+import { __testables__ } from './remitos-gestion.js';
+
+const { normalizeRemitoForDisplay } = __testables__;
+
+describe('normalizeRemitoForDisplay', () => {
+    it('mapea campos alternativos como NombreCliente y FechaCreacion', () => {
+        const remito = normalizeRemitoForDisplay({
+            NumeroRemito: 'REM-0001',
+            NumeroReporte: 'REP-2024-001',
+            NombreCliente: 'Cliente Demo',
+            FechaCreacion: '2024-05-01',
+            Direccion: 'Calle Falsa 123',
+            Telefono: '+54 11 5555-5555',
+            MailCliente: 'cliente@example.com',
+            MailTecnico: 'tecnico@example.com',
+            Observaciones: 'Sin novedades',
+            IdUnico: 'ID-XYZ-123',
+        });
+
+        expect(remito).toMatchObject({
+            numeroRemito: 'REM-0001',
+            numeroReporte: 'REP-2024-001',
+            cliente: 'Cliente Demo',
+            fechaRemito: '2024-05-01',
+            direccion: 'Calle Falsa 123',
+            telefono: '+54 11 5555-5555',
+            email: 'cliente@example.com',
+            tecnico: 'tecnico@example.com',
+            observaciones: 'Sin novedades',
+            reporteId: 'ID-XYZ-123',
+        });
+    });
+});

--- a/scripts/RemitoRepository2025.txt
+++ b/scripts/RemitoRepository2025.txt
@@ -9,6 +9,7 @@ const REMITOS_HEADERS = [
 ];
 
 const RemitoRepository = {
+  REMITOS_HEADERS,
   /**
    * Obtiene la hoja de Remitos. Si no existe, la crea con los encabezados.
    */
@@ -17,7 +18,7 @@ const RemitoRepository = {
     let sheet = ss.getSheetByName(REMITOS_SHEET_NAME);
     if (!sheet) {
       sheet = ss.insertSheet(REMITOS_SHEET_NAME);
-      sheet.appendRow(REMITOS_HEADERS);
+      sheet.appendRow(this.REMITOS_HEADERS);
       // Inmovilizar la primera fila (encabezados)
       sheet.setFrozenRows(1);
     }
@@ -47,5 +48,13 @@ const RemitoRepository = {
   guardar(remitoRowData) {
     const sheet = this.getSheet_();
     sheet.appendRow(remitoRowData);
+  },
+
+  /**
+   * Devuelve los encabezados configurados para la hoja de remitos.
+   * @returns {string[]} Lista de encabezados.
+   */
+  getHeaders() {
+    return this.REMITOS_HEADERS;
   }
 };

--- a/scripts/RemitoService 2025.txt
+++ b/scripts/RemitoService 2025.txt
@@ -79,7 +79,7 @@ const RemitoService = {
   obtenerRemitos(page = 1, pageSize = 20) {
     const sheet = RemitoRepository.getSheet_();
     const lastRow = sheet.getLastRow();
-    const headers = RemitoRepository.REMITOS_HEADERS; // Importante: Asegurarse de que REMITOS_HEADERS es accesible aquí
+    const headers = RemitoRepository.getHeaders();
 
     // Si solo hay encabezados o no hay datos, devolver un objeto vacío
     if (lastRow < 2) { 


### PR DESCRIPTION
## Summary
- map remito normalization to accept alternative headers like NombreCliente and FechaCreacion coming from the sheet
- add a unit test to guarantee the new mapping exposes client data in the UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5c1c49f308326aa0e401f9dea3317