### PR TITLE
Add remito ABM panel with CRUD actions

### DIFF
--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -131,3 +131,31 @@ export async function obtenerRemitos({ page = 1, pageSize = 20 } = {}) {
     });
 }
 
+export async function crearRemito(datos) {
+    return postJSON({
+        action: 'crear_remito',
+        ...datos,
+    });
+}
+
+export async function actualizarRemito(datos) {
+    return postJSON({
+        action: 'actualizar_remito',
+        ...datos,
+    });
+}
+
+export async function eliminarRemito(remitoId) {
+    if (remitoId && typeof remitoId === 'object') {
+        return postJSON({
+            action: 'eliminar_remito',
+            ...remitoId,
+        });
+    }
+
+    return postJSON({
+        action: 'eliminar_remito',
+        remitoId,
+    });
+}
+

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -1,13 +1,6 @@
 /* global __APP_VERSION__ */
 import { showView } from './viewManager.js';
-import {
-    guardarMantenimiento,
-    buscarMantenimientos,
-    actualizarMantenimiento,
-    eliminarMantenimiento,
-    obtenerDashboard,
-    obtenerClientes,
-} from './api.js';
+import * as api from './api.js';
 import { API_URL } from './config.js';
 import { initializeAuth, getCurrentToken } from './modules/login/auth.js';
 import { createDashboardModule } from './modules/dashboard/dashboard.js';
@@ -15,6 +8,19 @@ import { createMaintenanceModule } from './modules/mantenimiento/maintenance.js'
 import { createSearchModule } from './modules/busqueda/busqueda.js';
 import { createRemitoModule } from './modules/remito/remito.js';
 import { createRemitosGestionModule } from './modules/remitos-gestion/remitos-gestion.js';
+
+const {
+    guardarMantenimiento,
+    buscarMantenimientos,
+    actualizarMantenimiento,
+    eliminarMantenimiento,
+    obtenerDashboard,
+    obtenerClientes,
+    obtenerRemitos,
+    crearRemito,
+    actualizarRemito,
+    eliminarRemito,
+} = api;
 
 const remitoModule = createRemitoModule({
     showView,
@@ -53,7 +59,12 @@ const dashboardModule = createDashboardModule(
     { showView },
 );
 
-const remitosGestionModule = createRemitosGestionModule();
+const remitosGestionModule = createRemitosGestionModule({
+    obtenerRemitos,
+    crearRemito,
+    actualizarRemito,
+    eliminarRemito,
+});
 
 const appModules = {
     maintenance: maintenanceModule,


### PR DESCRIPTION
## Summary
- add API helpers for remito CRUD actions and expose them through the remitos management module
- rebuild the remitos management view with a form-driven workflow that supports creating, editing, and deleting remitos with inline feedback

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e5cc8cf2d48326983efc88e3e69ff8